### PR TITLE
Create gradle-publish.yml

### DIFF
--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -50,18 +50,15 @@ jobs:
         with:
           java-version: 11
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          settings-path: ${{ github.workspace }} # location for the settings.xml file
 
       - name: Build with Gradle
         run: ./gradlew build
 
-    #       The USERNAME and TOKEN need to correspond to the credentials environment variables used in
-    #       the publishing section of your build.gradle
       - name: Publish to GitHub Packages
         run: gradle publish -Prelease=true --no-build-cache
         env:
-          USERNAME: ${{ github.actor }}
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload p8e-api Artifact
         uses: actions/upload-artifact@v2

--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,17 @@ allprojects {
         apply plugin: 'maven-publish'
 
         publishing {
+            repositories {
+                maven {
+                    name = "GitHubPackages"
+                    url = "https://maven.pkg.github.com/provenance-io/p8e"
+                    credentials {
+                        username = System.getenv("GITHUB_ACTOR")
+                        password = System.getenv("GITHUB_TOKEN")
+                    }
+                }
+            }
+
             publications {
                 maven(MavenPublication) {
                     groupId = group


### PR DESCRIPTION
Setting up GitHub Actions CI Workflow for releases

1. Gradle build (just default `gradle build` command... not sure if gradlew is needed as this is a controlled environment that provides gradle for us...)
2. Publish build to GitHub Packages (added the `-Prelease=true` and `--no-build-cache` flags that we have been running)
3. Build and publish Docker images to Github Container Registry (p8e-api, p8e-migration, p8e-api-webservice)