### PR TITLE
add/push latest tag to docker image

### DIFF
--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -125,4 +125,6 @@ jobs:
           echo VERSION=$VERSION
 
           docker tag "${{ matrix.project }}:$VERSION" $IMAGE_ID:$VERSION
+          docker tag "${{ matrix.project }}:$VERSION" $IMAGE_ID:latest
           docker push $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:latest


### PR DESCRIPTION
- doesn't seem necessary to add another tag to the build step, should be good enough to run the tag command twice here and push to both