### PR TITLE
Fix/multiparty pre execution

### DIFF
--- a/p8e-common/src/main/kotlin/io/p8e/exception/Exception.kt
+++ b/p8e-common/src/main/kotlin/io/p8e/exception/Exception.kt
@@ -48,10 +48,10 @@ fun P8eError.isContractRetryable(): Boolean = when (this) {
     is P8eError.ContractDefinition -> false
     is P8eError.ContractValidation -> false
     is P8eError.ProtoParse -> false
-    is P8eError.NotFound -> true
-    is P8eError.ExecutionError -> true
-    is P8eError.PreExecutionError -> true
-    is P8eError.Unknown -> true
+    is P8eError.NotFound -> false
+    is P8eError.ExecutionError -> false
+    is P8eError.PreExecutionError -> false
+    is P8eError.Unknown -> false
 }
 
 /**

--- a/p8e-sdk/src/main/kotlin/io/p8e/proxy/Contract.kt
+++ b/p8e-sdk/src/main/kotlin/io/p8e/proxy/Contract.kt
@@ -432,7 +432,7 @@ class Contract<T: P8eContract>(
     fun getStagedExecutionUuid() = stagedExecutionUuid
 
     private fun packageContract(): Envelope {
-        if (executed.getAndSet(true))
+        if (executed.get(true))
             return this.executionEnvelope
 
         this.stagedContract = populateContract()
@@ -458,6 +458,8 @@ class Contract<T: P8eContract>(
             }
             .clearSignatures()
             .build()
+
+        executed.set(true)
 
         // Save spec in case its not loaded
         // TODO This probably should be removed since we can't on the fly install specs.

--- a/p8e-sdk/src/main/kotlin/io/p8e/proxy/Contract.kt
+++ b/p8e-sdk/src/main/kotlin/io/p8e/proxy/Contract.kt
@@ -432,7 +432,7 @@ class Contract<T: P8eContract>(
     fun getStagedExecutionUuid() = stagedExecutionUuid
 
     private fun packageContract(): Envelope {
-        if (executed.get(true))
+        if (executed.get())
             return this.executionEnvelope
 
         this.stagedContract = populateContract()
@@ -460,10 +460,6 @@ class Contract<T: P8eContract>(
             .build()
 
         executed.set(true)
-
-        // Save spec in case its not loaded
-        // TODO This probably should be removed since we can't on the fly install specs.
-        saveSpec(contractManager)
 
         permissionUpdater.saveProposedFacts(this.stagedExecutionUuid.toUuidProv(), this.stagedProposedProtos)
 


### PR DESCRIPTION
Fixes two bugs that were noticed recently:
- Setting `this.executionEnvelope` can fail after the atomic boolean is already set to true. When it is retried it will be short circuited and an empty envelope is submitted to the backend. It ends up failing for being empty.
- Cross scope facts were being fetched as protos and then saved back to object store from protos. This is needed to permission cross scope facts for recitals that are brand new to the scope. There's an edge case where the bytes into a proto is different than the bytes out of a proto. This leads to new recital members not getting access to the exact hash they should even though the protos remain equivalent in this case.