### PR TITLE
Upgrade deps.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,13 +45,13 @@ allprojects {
         implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson_version"
         implementation "com.fasterxml.jackson.core:jackson-annotations:$jackson_version"
 
-        implementation group: 'com.google.guava', name: 'guava', version: '27.1-jre'
+        implementation group: 'com.google.guava', name: 'guava', version: '30.1.1-jre'
         implementation 'org.slf4j:log4j-over-slf4j:1.7.30'
         implementation "javax.inject:javax.inject:1"
 
-        testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
+        testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.8.0'
         testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
-        testImplementation 'org.mockito:mockito-inline:2.8.9'
+        testImplementation 'org.mockito:mockito-inline:3.8.0'
 
         testCompileOnly(
                 "junit:junit:$junit_version"

--- a/event-stream/build.gradle
+++ b/event-stream/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation "javax.annotation:javax.annotation-api:1.3.1"
+    implementation "javax.annotation:javax.annotation-api:$javax_annotation_version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 
     compile "com.google.protobuf:protobuf-java:$protobuf_version"

--- a/os-proto/build.gradle
+++ b/os-proto/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation group: 'io.grpc', name: 'grpc-stub', version: grpc_version
 
     // Annotations
-    implementation 'javax.annotation:javax.annotation-api:1.3.1'
+    implementation("javax.annotation:javax.annotation-api:$javax_annotation_version")
 }
 
 protobuf {

--- a/p8e-api-webservice/build.gradle
+++ b/p8e-api-webservice/build.gradle
@@ -87,8 +87,7 @@ dependencies {
     implementation 'ch.qos.logback:logback-core:1.2.3'
 
     // Test Things
-    testImplementation 'com.h2database:h2:1.0.60'
-    testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
+    testImplementation 'com.h2database:h2:1.4.200'
 }
 
 def profiles = System.getenv("SPRING_PROFILES_ACTIVE") ?: "development"

--- a/p8e-api/build.gradle
+++ b/p8e-api/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:$springboot_version"
         classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlin_version"
-        classpath 'com.google.gradle:osdetector-gradle-plugin:1.6.2'
+        classpath 'com.google.gradle:osdetector-gradle-plugin:1.7.0'
     }
 }
 
@@ -98,17 +98,13 @@ dependencies {
 
     // GRPC
     implementation "io.grpc:grpc-netty-shaded:$grpc_version"
-    implementation("io.grpc:grpc-netty:$grpc_version") {
-        force true
-    }
-    implementation("io.netty:netty-handler:4.1.48.Final") {
-        force true
-    }
+    implementation("io.grpc:grpc-netty:$grpc_version")
+    implementation("io.netty:netty-handler:$netty_handler_version")
 
     if (osdetector.os == 'macos' || osdetector.os == 'freebsd') {
-        implementation('io.netty:netty-transport-native-kqueue:4.1.50.Final:osx-x86_64')
+        implementation("io.netty:netty-transport-native-kqueue:$netty_transport_version:osx-x86_64")
     } else if (osdetector.os == 'linux') {
-        implementation('io.netty:netty-transport-native-epoll:4.1.50.Final:linux-x86_64')
+        implementation("io.netty:netty-transport-native-epoll:$netty_transport_version:linux-x86_64")
     }
 
     // WebSocket
@@ -127,9 +123,6 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-actuator:$springboot_version"
     implementation 'io.github.lognet:grpc-spring-boot-starter:3.4.3'
     implementation "org.springframework.boot:spring-boot-starter-validation:$springboot_version"
-
-    // This compile is found on compile classpath of this component and consumers.
-    implementation 'com.google.guava:guava:23.0'
 
     // Just SQL Things
     implementation "org.postgresql:postgresql:$postgres_version"
@@ -170,7 +163,7 @@ jacocoTestReport {
     }
 }
 
-def profiles = System.getenv("SPRING_PROFILES_ACTIVE") ?: "development"
+def profiles = System.getenv("SPRING_PROFILES_ACTIVE") ?: "local"
 bootRun {
     args = ["--spring.profiles.active=$profiles"]
 }

--- a/p8e-common/build.gradle
+++ b/p8e-common/build.gradle
@@ -29,12 +29,12 @@ dependencies {
     implementation "io.github.openfeign:feign-core:10.2.3"
     implementation "com.auth0:java-jwt:$jwt_version"
 
-    implementation "io.netty:netty-handler:4.1.48.Final"
-    implementation 'io.netty:netty-tcnative-boringssl-static:2.0.31.Final'
-    implementation "io.grpc:grpc-api:$grpc_version"
-    implementation "io.grpc:grpc-netty:$grpc_version"
+    implementation("io.netty:netty-handler:$netty_handler_version")
+    implementation("io.netty:netty-tcnative-boringssl-static:$netty_ssl_version")
+    implementation("io.grpc:grpc-api:$grpc_version")
+    implementation("io.grpc:grpc-netty:$grpc_version")
     implementation("io.grpc:grpc-protobuf:$grpc_version")
-    implementation group: 'io.grpc', name: 'grpc-stub', version: grpc_version
+    implementation("io.grpc:grpc-stub:$grpc_version")
 
     implementation group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: bouncy_castle
 

--- a/p8e-index-client/build.gradle
+++ b/p8e-index-client/build.gradle
@@ -5,8 +5,8 @@ dependencies {
     implementation project(":p8e-proto-internal")
     implementation project(":p8e-util")
 
-    implementation "com.google.protobuf:protobuf-java:$protobuf_version"
-    implementation group: 'io.grpc', name: 'grpc-stub', version: grpc_version
+    implementation("com.google.protobuf:protobuf-java:$protobuf_version")
+    implementation("io.grpc:grpc-stub:$grpc_version")
 
-    api("org.elasticsearch.client:elasticsearch-rest-high-level-client:7.4.1")
+    api("org.elasticsearch.client:elasticsearch-rest-high-level-client:$elasticsearch_version")
 }

--- a/p8e-migration/build.gradle
+++ b/p8e-migration/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     dependencies {
-        classpath 'org.postgresql:postgresql:42.2.5'
+        classpath "org.postgresql:postgresql:$postgres_version"
     }
 }
 

--- a/p8e-proto-internal/build.gradle
+++ b/p8e-proto-internal/build.gradle
@@ -13,7 +13,7 @@ plugins {
 sourceSets.main.java.srcDirs += 'build/generated/source/proto/main/java'
 
 dependencies {
-    implementation "javax.annotation:javax.annotation-api:1.3.1"
+    implementation "javax.annotation:javax.annotation-api:$javax_annotation_version"
     implementation "com.google.protobuf:protobuf-java:$protobuf_version"
     implementation "com.google.protobuf:protobuf-java-util:$protobuf_version"
 

--- a/p8e-sdk/build.gradle
+++ b/p8e-sdk/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.google.gradle:osdetector-gradle-plugin:1.6.2'
+        classpath 'com.google.gradle:osdetector-gradle-plugin:1.7.0'
     }
 }
 
@@ -23,31 +23,24 @@ dependencies {
     api("io.arrow-kt:arrow-core:$arrow_version")
 
     // Ketherium utilities
-    implementation "com.github.komputing.kethereum:model:$kethereum_version"
+    implementation("com.github.komputing.kethereum:model:$kethereum_version")
 
-    implementation('com.google.guava:guava:23.0')
+    implementation("org.javassist:javassist:3.27.0-GA")
 
-    implementation("org.javassist:javassist:3.25.0-GA")
+    implementation("org.bouncycastle:bcpkix-jdk15on:$bouncy_castle")
 
-    implementation group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: bouncy_castle
-
-    implementation group: 'io.grpc', name: 'grpc-stub', version: grpc_version
-    implementation "com.google.protobuf:protobuf-java:$protobuf_version"
-    implementation "com.google.protobuf:protobuf-java-util:$protobuf_version"
-    implementation("io.netty:netty-tcnative-boringssl-static:2.0.31.Final")
-    implementation("io.grpc:grpc-netty:$grpc_version") {
-        force true
-    }
-    implementation("io.netty:netty-handler:4.1.48.Final") {
-        force true
-    }
+    implementation("io.grpc:grpc-stub:$grpc_version")
+    implementation("com.google.protobuf:protobuf-java:$protobuf_version")
+    implementation("com.google.protobuf:protobuf-java-util:$protobuf_version")
+    implementation("io.netty:netty-tcnative-boringssl-static:$netty_ssl_version")
+    implementation("io.grpc:grpc-netty:$grpc_version")
+    implementation("io.netty:netty-handler:$netty_handler_version")
 
     if (osdetector.os == 'macos' || osdetector.os == 'freebsd') {
-        implementation('io.netty:netty-transport-native-kqueue:4.1.50.Final:osx-x86_64')
+        implementation("io.netty:netty-transport-native-kqueue:$netty_transport_version:osx-x86_64")
     } else if (osdetector.os == 'linux') {
-        implementation('io.netty:netty-transport-native-epoll:4.1.50.Final:linux-x86_64')
+        implementation("io.netty:netty-transport-native-epoll:$netty_transport_version:linux-x86_64")
     }
 
-    testImplementation('com.github.javafaker:javafaker:0.15')
-    testImplementation('com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0')
+    testImplementation('com.github.javafaker:javafaker:1.0.2')
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,19 +1,21 @@
 // Versions shared across subprojects
 ext {
     arrow_version = '0.11.0'
-    identity_version = 'master-184'
-    elasticsearch_version = '7.4.1'
-    bouncy_castle = '1.63'
-    kotlin_version = '1.4.30'
+    elasticsearch_version = '7.12.0'
+    bouncy_castle = '1.68'
+    kotlin_version = '1.4.32'
     jackson_version = '2.12.2'
     junit_version = '4.12'
-    jupiter_version = '5.3.2'
-    jwt_version = "3.8.2"
-    postgres_version = '42.2.16'
+    jupiter_version = '5.7.1'
+    jwt_version = "3.14.0"
+    postgres_version = '42.2.19'
     exposed_version = '0.29.1'
     hikari_cp_version = '3.2.0'
-    redisson_version = '3.11.0'
-    grpc_version = '1.32.2'
+    redisson_version = '3.15.2'
+    grpc_version = '1.36.1'
+    netty_handler_version = '4.1.60.Final'
+    netty_transport_version = '4.1.60.Final'
+    netty_ssl_version = '2.0.38.Final'
     scarlet_version = '0.1.11'
     protobuf_version = '3.6.1'
     kethereum_version = '0.83.4'
@@ -21,6 +23,7 @@ ext {
     feign_version = '10.2.3'
     datadog_version = '2.11.0'
     logback_version = '1.2.3'
+    javax_annotation_version = '1.3.2'
 
     gradle_download = '4.1.1'
     provenance_version = '0.3.0'


### PR DESCRIPTION
Upgrades dependencies based on out dated dependencies read by the https://github.com/ben-manes/gradle-versions-plugin tool. The following is my local configuration.

```
def isNonStable = { String version ->
  def stableKeyword = ['RELEASE', 'FINAL', 'GA', 'JRE'].any { it -> version.toUpperCase().contains(it) }
  def regex = /^[0-9,.v-]+(-r)?$/
  return !stableKeyword && !(version ==~ regex)
}

initscript {
  repositories {
     gradlePluginPortal()
  }

  dependencies {
    classpath 'com.github.ben-manes:gradle-versions-plugin:+'
  }
}

allprojects {
  apply plugin: com.github.benmanes.gradle.versions.VersionsPlugin

  tasks.named("dependencyUpdates").configure {
    rejectVersionIf {
      isNonStable(it.candidate.version)
    }
  }
}
```

Things I didn't upgrade because I know they can require additional verbose testing:
- Spring
- Jackson
- Kethereum

## Tests
- [x] I ran a server without these changes and ran a client on both a stable version and this version. Both client versions worked with successful contract executions and also correctly printed trailing headers.
- [x] I ran a server with these changes and ran a client on both a stable version and this version. Both client versions worked with successful contract executions and also correctly printed trailing headers.