### PR TITLE
Don't push to latest tag on prereleases.

### DIFF
--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -118,7 +118,7 @@ jobs:
         run: docker build ${{ matrix.project }} --file ${{ matrix.project }}/docker/Dockerfile --tag "${{ matrix.project }}:$VERSION"
 
       - name: Log into registry
-        run: echo "${{ secrets.DOCKER_REGISTRY_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image
         run: |

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -136,7 +136,7 @@ jobs:
           PRERELEASE=${{ github.event.release.prerelease }}
           echo PRERELEASE=$PRERELEASE
 
-          if [["$PRERELEASE" == "false" ]]; then
+          if [ "$PRERELEASE" == "false" ]; then
               docker tag "${{ matrix.project }}:$VERSION" $IMAGE_ID:latest
               docker push $IMAGE_ID:latest
           fi

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -131,6 +131,12 @@ jobs:
           echo VERSION=$VERSION
 
           docker tag "${{ matrix.project }}:$VERSION" $IMAGE_ID:$VERSION
-          docker tag "${{ matrix.project }}:$VERSION" $IMAGE_ID:latest
           docker push $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:latest
+
+          PRERELEASE=${{ github.event.release.prerelease }}
+          echo PRERELEASE=$PRERELEASE
+
+          if [["$PRERELEASE" == "false" ]]; then
+              docker tag "${{ matrix.project }}:$VERSION" $IMAGE_ID:latest
+              docker push $IMAGE_ID:latest
+          fi


### PR DESCRIPTION
## Description

As it currently stands we are pushing to docker `:latest` tag on prereleases.
