### PR TITLE
Allow key and value in tx result from provenance grpc to be nullable.

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/batch/TxErrorReaper.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/batch/TxErrorReaper.kt
@@ -90,6 +90,7 @@ class TxErrorReaper(
 
     private fun Event.toScopeEvent(): ScopeEvent = ScopeEvent(findTxHash(), findScope(), type.toEventType())
 
-    private fun Attribute.toScope(): Scope = value.base64Decode().let { Scope.parseFrom(it) }
+    // We only call this after we find a matching "key" so it should be safe to convert to non nullable
+    private fun Attribute.toScope(): Scope = value!!.base64Decode().let { Scope.parseFrom(it) }
         ?: throw IllegalStateException("Event attribute does not contain a scope")
 }

--- a/p8e-api/src/main/kotlin/io/provenance/engine/domain/Transaction.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/domain/Transaction.kt
@@ -67,7 +67,7 @@ data class BlockResults(
 data class TxResult(
     val code: Int?,
     val data: String?,
-    val log: String,
+    val log: String?,
     val info: String,
     val gasWanted: Long,
     val gasUsed: Long,

--- a/p8e-api/src/main/kotlin/io/provenance/engine/stream/ScopeStream.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/stream/ScopeStream.kt
@@ -102,8 +102,9 @@ class ScopeStream(
             ?: throw IllegalStateException("Event does not contain a scope")
 
     // Parse a scope from an attribute value.
+    // We only call this after we find a matching "key" so it should be safe to convert to non nullable
     private fun Attribute.toScope(): Scope =
-        Scope.parseFrom(this.value.base64Decode())
+        Scope.parseFrom(this.value!!.base64Decode())
 
     // Queue a batch of scopes for indexing.
     fun queueIndexScopes(blockHeight: Long, events: List<ScopeEvent>) = timed("ScopeStream_indexScopes_${events.size}") {

--- a/p8e-api/src/main/kotlin/io/provenance/engine/stream/domain/WebSocket.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/stream/domain/WebSocket.kt
@@ -60,11 +60,11 @@ data class StreamEvent(
 )
 
 class Attribute(
-    key: ByteArray,
-    value: ByteArray
+    key: ByteArray?,
+    value: ByteArray?
 ) {
-    val key = String(key)
-    val value = String(value)
+    val key: String? = key?.let { String(it) }
+    val value: String? = value?.let {String(it) }
 }
 
 class Subscribe(


### PR DESCRIPTION
## Description

```
Caused by: feign.FeignException: Instantiation of [simple type, class io.provenance.engine.stream.domain.Attribute] value failed for JSON property value due to missing (therefore NULL) value for creator parameter value which is a non-nullable type

 at [Source: (BufferedReader); line: 38, column: 15] (through reference chain: io.provenance.engine.stream.domain.RPCResponse["result"]->io.provenance.engine.domain.BlockResults["txs_results"]->java.util.ArrayList[0]->io.provenance.engine.domain.TxResult["events"]->java.util.ArrayList[1]->io.provenance.engine.stream.domain.Event["attributes"]->java.util.ArrayList[2]->io.provenance.engine.stream.domain.Attribute["value"]) reading GET http://35.190.171.250:26657/

	at feign.FeignException.errorReading(FeignException.java:151)

	at feign.AsyncResponseHandler.handleResponse(AsyncResponseHandler.java:102)

	at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:138)

	at feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:89)

	at feign.ReflectiveFeign$FeignInvocationHandler.invoke(ReflectiveFeign.java:100)

	at com.sun.proxy.$Proxy116.blockResults(Unknown Source)
```
