### PR TITLE
fix event stream duplication

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/stream/EventStream.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/stream/EventStream.kt
@@ -110,15 +110,20 @@ class EventStreamFactory(
         fun streamEvents() {
             // todo: concurrency - need to limit how many times this function is called??? Used to limit based on consumer id... probably need to use redis to do this... and ensure cleaned up when shutting down if do
 
-            // start event loop to start listening for events
-            startEventLoop()
-            shutdownHook = shutdownHook { shutdown(false) } // ensure we close socket gracefully when shutting down
+            try {
+                // start event loop to start listening for events
+                startEventLoop()
+                shutdownHook = shutdownHook { shutdown(false) } // ensure we close socket gracefully when shutting down
 
-            timed("EventStream:streamHistory") {
-                streamHistory()
+                timed("EventStream:streamHistory") {
+                    streamHistory()
+                }
+
+                eventMonitor.start()
+            } catch (t: Throwable) {
+                log.error("Error starting up EventStream: ${t.message}")
+                handleError(t)
             }
-
-            eventMonitor.start()
         }
 
         private fun streamHistory() {

--- a/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/util/MDC.kt
+++ b/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/util/MDC.kt
@@ -62,9 +62,9 @@ object P8eMDC {
     }
 }
 
-data class TransactionHashes(val hashes: List<String>)
+data class TransactionHashes(val hashes: Collection<String>)
 fun String.toTransactionHashes() = TransactionHashes(listOf(this))
-fun List<String>.toTransactionHashes() = TransactionHashes(this)
+fun List<String>.toTransactionHashes() = TransactionHashes(this.toSet())
 
 data class BlockHeight(val height: Long)
 fun Long.toBlockHeight() = BlockHeight(this)


### PR DESCRIPTION
## Description

if there were network or other issues that caused an event stream restart, and those network issues also caused errors in the streamHistory logic, then the event stream websocket could end up connected multiple times, duplicating broadcasted events
