### PR TITLE
Add support for auth public key

### DIFF
--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/AffiliateController.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/AffiliateController.kt
@@ -21,7 +21,7 @@ open class AffiliateController(private val affiliateRepository: AffiliateReposit
 
     @PostMapping("")
     fun add(@RequestBody body: RegisterAffiliateKey) = affiliateRepository
-        .create(body.signingKeyPair, body.encryptionKeyPair, body.authPublicKey, body.indexName, body.alias)
+        .create(body.signingKeyPair, body.encryptionKeyPair, body.authKeyPair, body.indexName, body.alias)
 
     @GetMapping("{affiliatePublicKey}/shares")
     fun getShares(@PathVariable("affiliatePublicKey") affiliatePublicKey: String) = affiliatePublicKey.toJavaPublicKey()

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/AffiliateController.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/AffiliateController.kt
@@ -21,7 +21,7 @@ open class AffiliateController(private val affiliateRepository: AffiliateReposit
 
     @PostMapping("")
     fun add(@RequestBody body: RegisterAffiliateKey) = affiliateRepository
-        .create(body.signingKeyPair, body.encryptionKeyPair, body.indexName, body.alias)
+        .create(body.signingKeyPair, body.encryptionKeyPair, body.authPublicKey, body.indexName, body.alias)
 
     @GetMapping("{affiliatePublicKey}/shares")
     fun getShares(@PathVariable("affiliatePublicKey") affiliatePublicKey: String) = affiliatePublicKey.toJavaPublicKey()

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/domain/ApiAffiliate.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/domain/ApiAffiliate.kt
@@ -43,9 +43,10 @@ fun AffiliateShareRecord.toApi(): ApiAffiliateShare =
         created
     )
 
-data class RegisterAffiliateKey(val signingPrivateKey: String?, val encryptionPrivateKey: String?, val useSigningKeyForEncryption: Boolean, val indexName: String, val alias: String?) {
+data class RegisterAffiliateKey(val signingPrivateKey: String?, val encryptionPrivateKey: String?, val authKeyPair: String?, val useSigningKeyForEncryption: Boolean, val indexName: String, val alias: String?) {
     val signingKeyPair: KeyPair = signingPrivateKey.toOrGenerateKeyPair()
     val encryptionKeyPair: KeyPair = signingKeyPair.takeIf { useSigningKeyForEncryption }.or { encryptionPrivateKey.toOrGenerateKeyPair() }
+    val authPublicKey: PublicKey = authKeyPair.toOrGenerateKeyPair().public
 
     private fun String?.toOrGenerateKeyPair() = this?.takeIf { it.isNotBlank() }?.toJavaPrivateKey()?.let {
         KeyPair(it.computePublicKey(), it)

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/domain/ApiAffiliate.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/domain/ApiAffiliate.kt
@@ -43,10 +43,10 @@ fun AffiliateShareRecord.toApi(): ApiAffiliateShare =
         created
     )
 
-data class RegisterAffiliateKey(val signingPrivateKey: String?, val encryptionPrivateKey: String?, val authKeyPair: String?, val useSigningKeyForEncryption: Boolean, val indexName: String, val alias: String?) {
+data class RegisterAffiliateKey(val signingPrivateKey: String?, val encryptionPrivateKey: String?, val authPrivateKey: String?, val useSigningKeyForEncryption: Boolean, val indexName: String, val alias: String?) {
     val signingKeyPair: KeyPair = signingPrivateKey.toOrGenerateKeyPair()
     val encryptionKeyPair: KeyPair = signingKeyPair.takeIf { useSigningKeyForEncryption }.or { encryptionPrivateKey.toOrGenerateKeyPair() }
-    val authPublicKey: PublicKey = authKeyPair.toOrGenerateKeyPair().public
+    val authKeyPair: KeyPair = authPrivateKey.toOrGenerateKeyPair()
 
     private fun String?.toOrGenerateKeyPair() = this?.takeIf { it.isNotBlank() }?.toJavaPrivateKey()?.let {
         KeyPair(it.computePublicKey(), it)

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/repository/AffiliateRepository.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/repository/AffiliateRepository.kt
@@ -26,11 +26,11 @@ class AffiliateRepository(private val affiliateService: AffiliateService) {
             .map { it.toApi() }
     }
 
-    fun create(signingKeyPair: KeyPair, encryptionKeyPair: KeyPair, authPublicKey: PublicKey, indexName: String?, alias: String?): ApiAffiliateKey = transaction {
+    fun create(signingKeyPair: KeyPair, encryptionKeyPair: KeyPair, authKeyPair: KeyPair, indexName: String?, alias: String?): ApiAffiliateKey = transaction {
         affiliateService.save(
             signingKeyPair,
             encryptionKeyPair,
-            authPublicKey,
+            authKeyPair.public,
             indexName,
             alias,
             provenanceJwt(),

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/repository/AffiliateRepository.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/repository/AffiliateRepository.kt
@@ -26,10 +26,11 @@ class AffiliateRepository(private val affiliateService: AffiliateService) {
             .map { it.toApi() }
     }
 
-    fun create(signingKeyPair: KeyPair, encryptionKeyPair: KeyPair, indexName: String?, alias: String?): ApiAffiliateKey = transaction {
+    fun create(signingKeyPair: KeyPair, encryptionKeyPair: KeyPair, authPublicKey: PublicKey, indexName: String?, alias: String?): ApiAffiliateKey = transaction {
         affiliateService.save(
             signingKeyPair,
             encryptionKeyPair,
+            authPublicKey,
             indexName,
             alias,
             provenanceJwt(),

--- a/p8e-api/src/main/kotlin/io/provenance/engine/grpc/v1/AffiliateGrpc.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/grpc/v1/AffiliateGrpc.kt
@@ -10,6 +10,7 @@ import io.p8e.proto.AffiliateServiceGrpc.AffiliateServiceImplBase
 import io.p8e.util.computePublicKey
 import io.p8e.util.toHex
 import io.p8e.util.toPrivateKey
+import io.p8e.util.toPublicKey
 import io.provenance.p8e.shared.extension.logger
 import io.provenance.engine.grpc.interceptors.JwtServerInterceptor
 import io.provenance.engine.grpc.interceptors.UnhandledExceptionInterceptor
@@ -40,6 +41,8 @@ class AffiliateGrpc(
         val ecPrivateKey = if(request.encryptionPrivateKey.isInitialized) request.encryptionPrivateKey.toPrivateKey() else privateKey
         val ecPublicKey = ecPrivateKey.computePublicKey()
 
+        val authPublicKey = request.authPublicKey.toPublicKey()
+
         log.info("Saving affiliate encryption key: ${ecPublicKey.toHex()}")
 
         if (mailboxService.encryptionPublicKeyExists(ecPublicKey)) {
@@ -49,7 +52,8 @@ class AffiliateGrpc(
         transaction {
             affiliateService.save(
                 signingKeyPair = KeyPair(publicKey, privateKey),
-                encryptionKeyPair = KeyPair(ecPublicKey, ecPrivateKey)
+                encryptionKeyPair = KeyPair(ecPublicKey, ecPrivateKey),
+                authPublicKey = authPublicKey
             )
         }
         responseObserver.complete()

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/AuthenticationService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/AuthenticationService.kt
@@ -3,6 +3,7 @@ package io.provenance.engine.service
 import io.p8e.grpc.Constant
 import io.p8e.proto.Authentication
 import io.p8e.util.toHex
+import io.p8e.util.toJavaPublicKey
 import io.p8e.util.toPublicKey
 import io.provenance.p8e.shared.extension.logger
 import io.p8e.util.toOffsetDateTimeProv
@@ -50,8 +51,9 @@ class AuthenticationService(
             return null
         }
 
+        // Verify signature against the auth public key we have on record.
         val verified = Signature.getInstance(Constant.JWT_ALGORITHM).apply {
-            initVerify(publicKey)
+            initVerify(affiliate.authPublicKey.toJavaPublicKey())
             update(request.token.toByteArray())
         }.verify(request.signature.toByteArray())
 

--- a/p8e-migration/sql/V67__Add_Auth_Public_Key_to_Affiliate.sql
+++ b/p8e-migration/sql/V67__Add_Auth_Public_Key_to_Affiliate.sql
@@ -1,0 +1,1 @@
+ALTER TABLE affiliate ADD COLUMN auth_public_key TEXT;

--- a/p8e-proto-internal/src/main/proto/p8e/affiliate.proto
+++ b/p8e-proto-internal/src/main/proto/p8e/affiliate.proto
@@ -18,6 +18,7 @@ service AffiliateService {
 message AffiliateRegisterRequest {
     PrivateKey signing_private_key = 1;
     PrivateKey encryption_private_key = 2;
+    PublicKey auth_public_key = 3;
 }
 
 message AffiliateContractWhitelist {

--- a/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/service/AffiliateService.kt
+++ b/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/service/AffiliateService.kt
@@ -174,8 +174,8 @@ class AffiliateService(
         AFFILIATE_INDEX_NAMES,
         AFFILIATE_INDEX_NAME
     ])
-    fun save(signingKeyPair: KeyPair, encryptionKeyPair: KeyPair, indexName: String? = null, alias: String? = null, jwt: String? = null, identityUuid: UUID? = null): AffiliateRecord =
-        AffiliateRecord.insert(signingKeyPair, encryptionKeyPair, indexName, alias)
+    fun save(signingKeyPair: KeyPair, encryptionKeyPair: KeyPair, authPublicKey: PublicKey, indexName: String? = null, alias: String? = null, jwt: String? = null, identityUuid: UUID? = null): AffiliateRecord =
+        AffiliateRecord.insert(signingKeyPair, encryptionKeyPair, authPublicKey, indexName, alias)
             .also {
                 // Register the key with object store so that it monitors for replication.
                 osClient.createPublicKey(encryptionKeyPair.public)
@@ -215,8 +215,8 @@ class AffiliateService(
         AFFILIATE_INDEX_NAMES,
         AFFILIATE_INDEX_NAME
     ])
-    fun save(signingPublicKey: PublicKey, encryptionKeyPair: KeyPair, indexName: String? = null, alias: String?, jwt: String? = null): AffiliateRecord =
-        AffiliateRecord.insert(signingPublicKey, encryptionKeyPair, indexName, alias)
+    fun save(signingPublicKey: PublicKey, encryptionKeyPair: KeyPair, authPublicKey: PublicKey, indexName: String? = null, alias: String?, jwt: String? = null): AffiliateRecord =
+        AffiliateRecord.insert(signingPublicKey, encryptionKeyPair, authPublicKey, indexName, alias)
             .also {
                 // Register the key with object store so that it monitors for replication.
                 osClient.createPublicKey(encryptionKeyPair.public)


### PR DESCRIPTION
Add the ability to auth against p8e-api with a auth public key. 

Motivation behind this change is to restrict the usage of private keys within the code base especially when adding a key management system where the private key is not easily accessible. Also, existing keys already serves a purpose throughout the entire system where adding an auth key relieves the security risks of P8e having to manage the private key and is now in the complete possession of the user when auth-ing against p8e-api.  