### PR TITLE
keep the memorialize thread alive, handle errors while fetching lates…

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
@@ -82,7 +82,13 @@ class ChaincodeInvokeService(
 
     init {
         thread(isDaemon = true, name = "bc-tx-batch") {
-            memorializeBatchTx()
+            while (true) {
+                try {
+                    memorializeBatchTx()
+                } catch (t: Throwable) {
+                    log.error("Unexpected error in memorializeBatchTx, restarting...")
+                }
+            }
         }
     }
 
@@ -90,13 +96,19 @@ class ChaincodeInvokeService(
         log.info("Starting bc-tx-batch thread")
 
         while(true) {
-            provenanceGrpc.getLatestBlock()
-                .takeIf { it.block.header.height > currentBlockHeight }
-                ?.let {
-                    log.info("Clearing blockScopeIds")
-                    currentBlockHeight = it.block.header.height
-                    blockScopeIds.clear()
-                }
+            try {
+                provenanceGrpc.getLatestBlock()
+                    .takeIf { it.block.header.height > currentBlockHeight }
+                    ?.let {
+                        log.info("Clearing blockScopeIds")
+                        currentBlockHeight = it.block.header.height
+                        blockScopeIds.clear()
+                    }
+            } catch (t: Throwable) {
+                log.error("Received error when fetching latest block, waiting 1s before trying again", t)
+                Thread.sleep(1000);
+                continue;
+            }
 
             // attempt to load the batch with scopes that were previously passed on due to not
                 // wanting to send the same scope in the same block

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
@@ -86,7 +86,7 @@ class ChaincodeInvokeService(
                 try {
                     memorializeBatchTx()
                 } catch (t: Throwable) {
-                    log.error("Unexpected error in memorializeBatchTx, restarting...")
+                    log.error("Unexpected error in memorializeBatchTx, restarting...", t)
                 }
             }
         }

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
@@ -105,7 +105,7 @@ class ChaincodeInvokeService(
                         blockScopeIds.clear()
                     }
             } catch (t: Throwable) {
-                log.error("Received error when fetching latest block, waiting 1s before trying again", t)
+                log.warn("Received error when fetching latest block, waiting 1s before trying again", t)
                 Thread.sleep(1000);
                 continue;
             }
@@ -137,8 +137,6 @@ class ChaincodeInvokeService(
             }
 
             while (batch.size < chaincodeProperties.txBatchSize) {
-                // TODO wrap poll in catch since there's cases where it can throw and if that happens
-                // this thread would currently be lost
                 queue.poll(chaincodeProperties.emptyIterationBackoffMS.toLong(), TimeUnit.MILLISECONDS)?.let { message ->
                     if (!blockScopeIds.contains(message.request.scopeId)) {
                         log.debug("adding ${message.request.scopeId} to batch")


### PR DESCRIPTION
Make sure the bc-tx-batch thread stays alive no matter what, and handle any error while fetching latest block height