### PR TITLE
handle missing scope specification record gracefully

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
@@ -219,6 +219,8 @@ class ChaincodeInvokeService(
                             batch.map {
                                 it.future.completeExceptionally(t)
                                 it.executionUuid
+                            }.also {
+                                batch.clear()
                             }
                         }
                     }

--- a/p8e-api/src/main/kotlin/io/provenance/engine/util/ProvenanceProtoExtensions.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/util/ProvenanceProtoExtensions.kt
@@ -72,7 +72,11 @@ fun Envelope.toProv(invokerAddress: String): MsgP8eMemorializeContractRequest =
         .setGroupId(this.ref.groupUuid.value)
         // TODO refactor name fetch to service with caching?
         // Does this need to verify that this scope specification is associated with this contract hash locally in the db as well?
-        .setScopeSpecificationId(transaction { ScopeSpecificationRecord.findByName(scope.scopeSpecificationName)?.id?.value?.toString() })
+        .apply {
+            transaction { ScopeSpecificationRecord.findByName(scope.scopeSpecificationName)?.id?.value?.toString() }?.let { scopeSpecificationId ->
+                setScopeSpecificationId(scopeSpecificationId)
+            }
+        }
         .setContract(this.contract.toProv().toBuilder()
             .setContext(Contracts.ContractState.newBuilder()
                 .setExecutionUuid(this.executionUuid)


### PR DESCRIPTION
- allow envelope to properly error out when the chain rejects due to invalid scope specification id
- previously, this would result in an envelope getting stuck at ENVELOPE_CHAINCODE COMPLETE, when in fact there was an error
- batch.clear() was moved, but needs to be present in this case where we error the whole batch, otherwise we keep retrying the batch and shipping errors back indefinitely