### PR TITLE
Ch88576/webservice smartkey updates

### DIFF
--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/AffiliateController.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/AffiliateController.kt
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.*
 import io.p8e.util.*
 import io.provenance.p8e.webservice.domain.*
 import io.provenance.p8e.webservice.repository.AffiliateRepository
+import io.provenance.p8e.webservice.util.toOrGenerateKeyPair
 
 // todo: remove CrossOrigin and let Kong handle this
 @CrossOrigin(origins = ["http://localhost:3000"], allowCredentials = "true")
@@ -20,8 +21,18 @@ open class AffiliateController(private val affiliateRepository: AffiliateReposit
     }
 
     @PostMapping("")
-    fun add(@RequestBody body: RegisterAffiliateKey) = affiliateRepository
-        .create(body.signingKeyPair, body.encryptionKeyPair, body.authKeyPair, body.indexName, body.alias)
+    fun add(@RequestBody body: RegisterAffiliateKey): ApiAffiliateKey {
+        if (body.signingPrivateKey != null || body.encryptionPrivateKey != null) {
+            require(body.keyProvider == KeyProviders.DATABASE) { "Supplying keys only supported for ${KeyProviders.DATABASE.key} provider" }
+            require(body.signingPrivateKey != null && body.encryptionPrivateKey != null) { "When providing existing private keys, you must supply both signing and encryption keys" }
+        }
+
+        return when(body.keyProvider) {
+            KeyProviders.DATABASE -> affiliateRepository
+                .create(body.signingPrivateKey.toOrGenerateKeyPair(), body.encryptionPrivateKey.toOrGenerateKeyPair(), body.indexName, body.alias)
+            KeyProviders.SMART_KEY -> affiliateRepository.create(body.indexName, body.alias)
+        }
+    }
 
     @GetMapping("{affiliatePublicKey}/shares")
     fun getShares(@PathVariable("affiliatePublicKey") affiliatePublicKey: String) = affiliatePublicKey.toJavaPublicKey()

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/AffiliateController.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/AffiliateController.kt
@@ -22,9 +22,9 @@ open class AffiliateController(private val affiliateRepository: AffiliateReposit
 
     @PostMapping("")
     fun add(@RequestBody body: RegisterAffiliateKey): ApiAffiliateKey {
-        if (body.signingPrivateKey != null || body.encryptionPrivateKey != null) {
+        if (body.hasSigningKey || body.hasEncryptionKey) {
             require(body.keyProvider == KeyProviders.DATABASE) { "Supplying keys only supported for ${KeyProviders.DATABASE.key} provider" }
-            require(body.signingPrivateKey != null && body.encryptionPrivateKey != null) { "When providing existing private keys, you must supply both signing and encryption keys" }
+            require(body.hasSigningKey && body.hasEncryptionKey) { "When providing existing private keys, you must supply both signing and encryption keys" }
         }
 
         return when(body.keyProvider) {

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/ObjectController.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/ObjectController.kt
@@ -25,7 +25,7 @@ open class ObjectController(private val affiliateService: AffiliateService) {
         val affiliate = transaction { affiliateService.getAffiliateByPublicKeyAndIdentityUuid(publicKey.toJavaPublicKey(), provenanceIdentityUuid()) }
 
         requireNotNull(affiliate) { "Identity ${provenanceIdentityUuid()} is unable to fetch objects for public key $publicKey" }
-        
+
         // todo: figure out how to properly authenticate to fetch object json now
         return ContractManager.create(affiliate.privateKey!!).let { cm ->
             cm.client.loadProtoJson(hash, className, contractSpecHash)

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/ObjectController.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/ObjectController.kt
@@ -26,7 +26,8 @@ open class ObjectController(private val affiliateService: AffiliateService) {
 
         requireNotNull(affiliate) { "Identity ${provenanceIdentityUuid()} is unable to fetch objects for public key $publicKey" }
 
-        return ContractManager.create(affiliate.privateKey).let { cm ->
+        // todo: figure out how to properly authenticate in order to fetch proto json now
+        return ContractManager.create(affiliate.privateKey!!).let { cm ->
             cm.client.loadProtoJson(hash, className, contractSpecHash)
         }
     }

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/domain/ApiAffiliate.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/domain/ApiAffiliate.kt
@@ -55,7 +55,10 @@ enum class KeyProviders(val key: String) {
         .orThrow { IllegalArgumentException("Key Provider $text does not exist") }
 }
 
-data class RegisterAffiliateKey(val signingPrivateKey: String?, val encryptionPrivateKey: String?, val useSigningKeyForEncryption: Boolean, val keyProvider: KeyProviders, val indexName: String, val alias: String?)
+data class RegisterAffiliateKey(val signingPrivateKey: String?, val encryptionPrivateKey: String?, val keyProvider: KeyProviders, val indexName: String, val alias: String?) {
+    val hasSigningKey = signingPrivateKey?.isNotBlank() == true
+    val hasEncryptionKey = encryptionPrivateKey?.isNotBlank() == true
+}
 
 data class UpdateAffiliateKey(val alias: String?)
 data class AddShare(val publicKey: String)

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/domain/ApiAffiliate.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/domain/ApiAffiliate.kt
@@ -46,13 +46,9 @@ fun AffiliateShareRecord.toApi(): ApiAffiliateShare =
         created
     )
 
-enum class KeyProviders(val key: String) {
-    DATABASE("database"),
-    SMART_KEY("smartKey");
-
-    @JsonCreator
-    fun fromText(text: String): KeyProviders = values().find { it.key == text }
-        .orThrow { IllegalArgumentException("Key Provider $text does not exist") }
+enum class KeyProviders {
+    DATABASE,
+    SMART_KEY,
 }
 
 data class RegisterAffiliateKey(val signingPrivateKey: String?, val encryptionPrivateKey: String?, val keyProvider: KeyProviders, val indexName: String, val alias: String?) {

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/domain/ApiAffiliate.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/domain/ApiAffiliate.kt
@@ -1,5 +1,6 @@
 package io.provenance.p8e.webservice.domain
 
+import com.fasterxml.jackson.annotation.JsonCreator
 import io.p8e.util.*
 import io.provenance.p8e.encryption.ecies.ProvenanceKeyGenerator
 import io.provenance.p8e.shared.domain.AffiliateRecord
@@ -14,17 +15,19 @@ data class ApiAffiliateKey(
         val alias: String?,
         val signingKey: ApiPublicKey,
         val encryptionKey: ApiPublicKey,
+        val authKey: ApiPublicKey,
         val indexName: String,
         val serviceKeys: List<ApiServiceKey>
 ) {
     val keyUsage = "CONTRACT"
 }
 
-fun AffiliateRecord.toApi(includePrivateKey: Boolean = false): ApiAffiliateKey {
+fun AffiliateRecord.toApi(authPrivateKey: String? = null): ApiAffiliateKey {
     return ApiAffiliateKey(
         alias,
-        ApiPublicKey(publicKey.value, hexPrivateKey = privateKey.takeIf { includePrivateKey }),
-        ApiPublicKey(encryptionPublicKey, hexPrivateKey = encryptionPrivateKey.takeIf { includePrivateKey }),
+        ApiPublicKey(publicKey.value),
+        ApiPublicKey(encryptionPublicKey),
+        ApiPublicKey(authPublicKey, hexPrivateKey = authPrivateKey),
         indexName,
         serviceKeys.map { it.toApi() }
     )
@@ -43,15 +46,16 @@ fun AffiliateShareRecord.toApi(): ApiAffiliateShare =
         created
     )
 
-data class RegisterAffiliateKey(val signingPrivateKey: String?, val encryptionPrivateKey: String?, val authPrivateKey: String?, val useSigningKeyForEncryption: Boolean, val indexName: String, val alias: String?) {
-    val signingKeyPair: KeyPair = signingPrivateKey.toOrGenerateKeyPair()
-    val encryptionKeyPair: KeyPair = signingKeyPair.takeIf { useSigningKeyForEncryption }.or { encryptionPrivateKey.toOrGenerateKeyPair() }
-    val authKeyPair: KeyPair = authPrivateKey.toOrGenerateKeyPair()
+enum class KeyProviders(val key: String) {
+    DATABASE("database"),
+    SMART_KEY("smartKey");
 
-    private fun String?.toOrGenerateKeyPair() = this?.takeIf { it.isNotBlank() }?.toJavaPrivateKey()?.let {
-        KeyPair(it.computePublicKey(), it)
-    } ?: ProvenanceKeyGenerator.generateKeyPair()
+    @JsonCreator
+    fun fromText(text: String): KeyProviders = values().find { it.key == text }
+        .orThrow { IllegalArgumentException("Key Provider $text does not exist") }
 }
+
+data class RegisterAffiliateKey(val signingPrivateKey: String?, val encryptionPrivateKey: String?, val useSigningKeyForEncryption: Boolean, val keyProvider: KeyProviders, val indexName: String, val alias: String?)
 
 data class UpdateAffiliateKey(val alias: String?)
 data class AddShare(val publicKey: String)

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/repository/AffiliateRepository.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/repository/AffiliateRepository.kt
@@ -2,6 +2,7 @@ package io.provenance.p8e.webservice.repository
 
 import io.p8e.util.orThrowNotFound
 import io.p8e.util.toHex
+import io.provenance.p8e.encryption.ecies.ProvenanceKeyGenerator
 import io.provenance.p8e.shared.domain.AffiliateRecord
 import io.provenance.p8e.shared.service.AffiliateService
 import io.provenance.p8e.webservice.controller.ApiServiceKey
@@ -11,31 +12,51 @@ import io.provenance.p8e.webservice.domain.ApiAffiliateKey
 import io.provenance.p8e.webservice.domain.ApiAffiliateShare
 import io.provenance.p8e.webservice.interceptors.provenanceIdentityUuid
 import io.provenance.p8e.webservice.interceptors.provenanceJwt
+import io.provenance.p8e.webservice.service.KeyManagementService
 import io.provenance.p8e.webservice.util.AccessDeniedException
 import org.jetbrains.exposed.dao.with
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.springframework.stereotype.Component
+import java.lang.IllegalArgumentException
 import java.security.KeyPair
+import java.security.PrivateKey
 import java.security.PublicKey
 
 @Component
-class AffiliateRepository(private val affiliateService: AffiliateService) {
+class AffiliateRepository(
+    private val affiliateService: AffiliateService,
+    private val keyManagementService: KeyManagementService,
+) {
     fun getAll(): List<ApiAffiliateKey> = transaction {
         affiliateService.getAllRegistered(provenanceIdentityUuid())
             .with(AffiliateRecord::serviceKeys)
             .map { it.toApi() }
     }
 
-    fun create(signingKeyPair: KeyPair, encryptionKeyPair: KeyPair, authKeyPair: KeyPair, indexName: String?, alias: String?): ApiAffiliateKey = transaction {
-        affiliateService.save(
-            signingKeyPair,
-            encryptionKeyPair,
-            authKeyPair.public,
-            indexName,
-            alias,
-            provenanceJwt(),
-            provenanceIdentityUuid()
-        ).toApi(true)
+    fun create(signingKeyPair: KeyPair, encryptionKeyPair: KeyPair, indexName: String?, alias: String?): ApiAffiliateKey = ProvenanceKeyGenerator.generateKeyPair()
+        .let { authKeyPair ->
+            transaction {
+                affiliateService.save(
+                    signingKeyPair,
+                    encryptionKeyPair,
+                    authKeyPair.public,
+                    indexName,
+                    alias,
+                    provenanceJwt(),
+                    provenanceIdentityUuid()
+                ).toApi(authKeyPair.private.toHex())
+            }
+        }
+
+    fun create(indexName: String?, alias: String?): ApiAffiliateKey {
+        val signingKey = keyManagementService.generateKey("$alias signing key")
+        val encryptionKey = keyManagementService.generateKey("$alias encryption key")
+        val authKeyPair = ProvenanceKeyGenerator.generateKeyPair()
+
+        return transaction {
+            affiliateService.save(signingKey, encryptionKey, authKeyPair.public, indexName, alias)
+                .toApi(authKeyPair.private.toHex())
+        }
     }
 
     fun update(publicKey: PublicKey, alias: String?): ApiAffiliateKey = transaction {

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/service/KeyManagementService.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/service/KeyManagementService.kt
@@ -1,0 +1,40 @@
+package io.provenance.p8e.webservice.service
+
+import com.fortanix.sdkms.v1.api.SecurityObjectsApi
+import com.fortanix.sdkms.v1.model.EllipticCurve
+import com.fortanix.sdkms.v1.model.ObjectType
+import com.fortanix.sdkms.v1.model.SobjectRequest
+import io.p8e.util.toJavaPublicKey
+import io.p8e.util.toUuidProv
+import io.provenance.p8e.shared.domain.ExternalKeyRef
+import java.security.KeyPair
+import java.util.*
+
+class KeyManagementService(private val securityObjectsApi: SecurityObjectsApi) {
+    fun importKey(keyPair: KeyPair, name: String?): ExternalKeyRef =
+        importOrGenerateKey(SobjectRequest()
+            .objType(ObjectType.EC)
+            .value(keyPair.private.encoded)
+            .name(name)
+        )
+
+    fun generateKey(name: String?): ExternalKeyRef =
+        importOrGenerateKey(SobjectRequest()
+            .objType(ObjectType.EC)
+            .ellipticCurve(EllipticCurve.SECP256K1)
+            .name(name)
+        )
+
+    fun updateName(uuid: UUID, name: String?) = securityObjectsApi
+        .updateSecurityObject(
+            uuid.toString(),
+            SobjectRequest().name(name)
+        )
+
+    fun deleteKey(uuid: UUID) = securityObjectsApi.deleteSecurityObject(uuid.toString())
+
+    private fun importOrGenerateKey(request: SobjectRequest): ExternalKeyRef = securityObjectsApi
+        .generateSecurityObject(request).run {
+            ExternalKeyRef(kid.toUuidProv(), toJavaPublicKey())
+        }
+}

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/service/KeyManagementService.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/service/KeyManagementService.kt
@@ -1,27 +1,35 @@
 package io.provenance.p8e.webservice.service
 
 import com.fortanix.sdkms.v1.api.SecurityObjectsApi
-import com.fortanix.sdkms.v1.model.EllipticCurve
-import com.fortanix.sdkms.v1.model.ObjectType
-import com.fortanix.sdkms.v1.model.SobjectRequest
+import com.fortanix.sdkms.v1.model.*
 import io.p8e.util.toJavaPublicKey
 import io.p8e.util.toUuidProv
 import io.provenance.p8e.shared.domain.ExternalKeyRef
+import io.provenance.p8e.shared.extension.logger
+import org.springframework.stereotype.Service
 import java.security.KeyPair
 import java.util.*
 
+enum class KeyUsageType(val options: List<KeyOperations>) {
+    SIGNING(listOf(KeyOperations.SIGN, KeyOperations.VERIFY, KeyOperations.APPMANAGEABLE)),
+    ENCRYPTION(listOf(KeyOperations.AGREEKEY, KeyOperations.APPMANAGEABLE)),
+}
+
+@Service
 class KeyManagementService(private val securityObjectsApi: SecurityObjectsApi) {
-    fun importKey(keyPair: KeyPair, name: String?): ExternalKeyRef =
+    fun importKey(keyPair: KeyPair, name: String?, keyUsageType: KeyUsageType): ExternalKeyRef =
         importOrGenerateKey(SobjectRequest()
             .objType(ObjectType.EC)
             .value(keyPair.private.encoded)
+            .keyOps(keyUsageType.options)
             .name(name)
         )
 
-    fun generateKey(name: String?): ExternalKeyRef =
+    fun generateKey(name: String?, keyUsageType: KeyUsageType): ExternalKeyRef =
         importOrGenerateKey(SobjectRequest()
             .objType(ObjectType.EC)
             .ellipticCurve(EllipticCurve.SECP256K1)
+            .keyOps(keyUsageType.options)
             .name(name)
         )
 

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/util/Extensions.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/util/Extensions.kt
@@ -3,7 +3,11 @@ package io.provenance.p8e.webservice.util
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectReader
 import com.fasterxml.jackson.databind.ObjectWriter
+import io.p8e.util.computePublicKey
 import io.p8e.util.configureProvenance
+import io.p8e.util.toJavaPrivateKey
+import io.provenance.p8e.encryption.ecies.ProvenanceKeyGenerator
+import java.security.KeyPair
 
 private val om = ObjectMapper().configureProvenance()
 private val oWriter = om.writer()
@@ -11,5 +15,9 @@ private val oReader = om.reader()
 
 fun Any.toJsonNode(ow: ObjectWriter = oWriter, or: ObjectReader = oReader) =
     or.readTree(ow.writeValueAsBytes(this))
+
+fun String?.toOrGenerateKeyPair() = this?.takeIf { it.isNotBlank() }?.toJavaPrivateKey()?.let {
+    KeyPair(it.computePublicKey(), it)
+} ?: ProvenanceKeyGenerator.generateKeyPair()
 
 class AccessDeniedException(message: String) : RuntimeException(message)

--- a/p8e-api-webservice/src/main/resources/application-development.properties
+++ b/p8e-api-webservice/src/main/resources/application-development.properties
@@ -34,3 +34,6 @@ objectstore.key=
 redis.host=localhost
 redis.port=6379
 redis.connection_pool_size=64
+
+# Smart Key
+smartkey.apikey=${SMARTKEY_API_KEY}

--- a/p8e-api-webservice/src/main/resources/application-local.properties
+++ b/p8e-api-webservice/src/main/resources/application-local.properties
@@ -45,3 +45,6 @@ provenance.oauth.ttl-seconds=300
 
 # Provenance Keystone
 provenance.keystone.url=https://test.provenance.io/keystone/key/registration/secured
+
+# Smart Key
+smartkey.apikey=${SMARTKEY_API_KEY}

--- a/p8e-api/src/main/kotlin/io/provenance/engine/config/AppConfig.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/config/AppConfig.kt
@@ -35,6 +35,7 @@ import io.provenance.os.mailbox.client.MailboxClient
 import io.provenance.os.mailbox.client.MailboxClientProperties
 import io.provenance.p8e.shared.config.JwtProperties
 import io.provenance.p8e.shared.config.ProvenanceKeystoneProperties
+import io.provenance.p8e.shared.config.SmartKeyProperties
 import io.provenance.p8e.shared.service.KeystoneService
 import io.provenance.pbc.clients.Denom
 import io.provenance.pbc.clients.SimpleClient

--- a/p8e-api/src/main/kotlin/io/provenance/engine/config/AppConfig.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/config/AppConfig.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fortanix.sdkms.v1.ApiClient
 import com.fortanix.sdkms.v1.api.AuthenticationApi
+import com.fortanix.sdkms.v1.api.SecurityObjectsApi
+import com.fortanix.sdkms.v1.api.SignAndVerifyApi
 import com.fortanix.sdkms.v1.auth.ApiKeyAuth
 import com.timgroup.statsd.NonBlockingStatsDClientBuilder
 import com.tinder.scarlet.Scarlet
@@ -54,10 +56,12 @@ import org.kethereum.bip39.toSeed
 import org.redisson.Redisson
 import org.redisson.api.RedissonClient
 import org.redisson.config.Config
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Scope
 import org.springframework.http.converter.HttpMessageConverter
 import org.springframework.http.converter.protobuf.ProtobufHttpMessageConverter
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
@@ -270,20 +274,29 @@ class AppConfig : WebMvcConfigurer {
      * Add support for new key management.
      */
     @Bean
-    fun signer(smartKeySigner: SmartKeySigner): SignerFactory {
-        return SignerFactory(smartKeySigner)
+    @Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
+    fun smartKeyApiClient(smartKeyProperties: SmartKeyProperties): ApiClient = ApiClient().apply {
+        setBasicAuthString(smartKeyProperties.apiKey)
+        com.fortanix.sdkms.v1.Configuration.setDefaultApiClient(this)
+
+        // authenticate with api
+        val authResponse = AuthenticationApi().authorize()
+        val auth = this.getAuthentication("bearerToken") as ApiKeyAuth
+        auth.apiKey = authResponse.accessToken
+        auth.apiKeyPrefix = "Bearer"
     }
 
     @Bean
-    fun smartKeySigner(smartKeyProperties: SmartKeyProperties): SmartKeySigner {
-        return SmartKeySigner().apply {
-            val client = ApiClient().apply { setBasicAuthString(smartKeyProperties.apiKey) }
-            com.fortanix.sdkms.v1.Configuration.setDefaultApiClient(client)
+    fun signAndVerifyApi(smartKeyApiClient: ApiClient): SignAndVerifyApi = SignAndVerifyApi(smartKeyApiClient)
 
-            val authResponse = AuthenticationApi().authorize()
-            val auth = client.getAuthentication("bearerToken") as ApiKeyAuth
-            auth.apiKey = authResponse.accessToken
-            auth.apiKeyPrefix = "Bearer"
-        }
+    @Bean
+    fun securityObjectsApi(smartKeyApiClient: ApiClient): SecurityObjectsApi = SecurityObjectsApi(smartKeyApiClient)
+
+    @Bean
+    fun smartKeySigner(signAndVerifyApi: SignAndVerifyApi, securityObjectsApi: SecurityObjectsApi): SmartKeySigner = SmartKeySigner(signAndVerifyApi, securityObjectsApi)
+
+    @Bean
+    fun signer(smartKeySigner: SmartKeySigner): SignerFactory {
+        return SignerFactory(smartKeySigner)
     }
 }

--- a/p8e-api/src/main/kotlin/io/provenance/engine/config/Properties.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/config/Properties.kt
@@ -136,8 +136,3 @@ class MetricsProperties {
     var tags: String = ""
     var prefix: String = "p8e_api"
 }
-
-@ConfigurationProperties(prefix = "smartkey")
-class SmartKeyProperties {
-    @NotNull lateinit var apiKey: String
-}

--- a/p8e-api/src/main/resources/application-development.properties
+++ b/p8e-api/src/main/resources/application-development.properties
@@ -80,5 +80,5 @@ metrics.collectors=file
 metrics.tags=env:local
 
 # Smart Key
-smartkey.apikey=
+smartkey.apikey=${SMARTKEY_API_KEY}
 

--- a/p8e-api/src/main/resources/application-local.properties
+++ b/p8e-api/src/main/resources/application-local.properties
@@ -81,6 +81,6 @@ metrics.collectors=file
 metrics.tags=env:local
 
 # Smart Key
-smartkey.apikey=
+smartkey.apikey=${SMARTKEY_API_KEY}
 
 

--- a/p8e-migration/sql/V70__Adjust_Encryption_Key_Columns.sql
+++ b/p8e-migration/sql/V70__Adjust_Encryption_Key_Columns.sql
@@ -1,0 +1,3 @@
+ALTER TABLE p8e.affiliate
+    ADD COLUMN encryption_key_uuid UUID,
+    ALTER COLUMN encryption_private_key DROP NOT NULL;

--- a/p8e-migration/sql/V70__Adjust_Encryption_Key_Columns.sql
+++ b/p8e-migration/sql/V70__Adjust_Encryption_Key_Columns.sql
@@ -1,3 +1,3 @@
-ALTER TABLE p8e.affiliate
+ALTER TABLE affiliate
     ADD COLUMN encryption_key_uuid UUID,
     ALTER COLUMN encryption_private_key DROP NOT NULL;

--- a/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/config/Properties.kt
+++ b/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/config/Properties.kt
@@ -21,3 +21,8 @@ class JwtProperties {
 class ProvenanceKeystoneProperties {
     @NotNull lateinit var url: String
 }
+
+@ConfigurationProperties(prefix = "smartkey")
+class SmartKeyProperties {
+    @NotNull lateinit var apiKey: String
+}

--- a/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/domain/Affiliate.kt
+++ b/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/domain/Affiliate.kt
@@ -25,8 +25,8 @@ object AffiliateTable : IdTable<String>("affiliate") {
     val encryptionPrivateKey = text ("encryption_private_key").nullable()
     val indexName = varchar("index_name", 255).default(DEFAULT_INDEX_NAME)
     val active = bool("active").default(true)
-    val keyUuid = uuid("key_uuid")
-    val encryptionKeyUuid = uuid("encryption_key_uuid")
+    val keyUuid = uuid("key_uuid").nullable()
+    val encryptionKeyUuid = uuid("encryption_key_uuid").nullable()
     val authPublicKey = text("auth_public_key")
 
     override val id: Column<EntityID<String>> = publicKey.entityId()

--- a/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/domain/Affiliate.kt
+++ b/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/domain/Affiliate.kt
@@ -22,10 +22,11 @@ object AffiliateTable : IdTable<String>("affiliate") {
     val privateKey = text("private_key").nullable()
     val whitelistData = proto("whitelist_data", AffiliateWhitelist.getDefaultInstance()).nullable()
     val encryptionPublicKey = text("encryption_public_key")
-    val encryptionPrivateKey = text ("encryption_private_key")
+    val encryptionPrivateKey = text ("encryption_private_key").nullable()
     val indexName = varchar("index_name", 255).default(DEFAULT_INDEX_NAME)
     val active = bool("active").default(true)
     val keyUuid = uuid("key_uuid")
+    val encryptionKeyUuid = uuid("encryption_key_uuid")
     val authPublicKey = text("auth_public_key")
 
     override val id: Column<EntityID<String>> = publicKey.entityId()
@@ -79,11 +80,12 @@ open class AffiliateEntityClass: EntityClass<String, AffiliateRecord>(
      * [indexName] Name of index for elasticsearch
      * [alias] Alias for affiliate
      */
-    fun insert(signingPublicKey: PublicKey, encryptionKeyPair: KeyPair, authPublicKey: PublicKey, indexName: String?, alias: String? = null) =
-        findForUpdate(signingPublicKey)
-            ?: new(signingPublicKey.toHex()) {
-                this.encryptionPrivateKey = encryptionKeyPair.private.toHex()
-                this.encryptionPublicKey = encryptionKeyPair.public.toHex()
+    fun insert(signingPublicKey: ExternalKeyRef, encryptionPublicKey: ExternalKeyRef, authPublicKey: PublicKey, indexName: String?, alias: String? = null) =
+        findForUpdate(signingPublicKey.publicKey)
+            ?: new(signingPublicKey.publicKey.toHex()) {
+                this.keyUuid = signingPublicKey.uuid
+                this.encryptionPublicKey = encryptionPublicKey.publicKey.toHex()
+                this.encryptionKeyUuid = encryptionPublicKey.uuid
                 this.authPublicKey = authPublicKey.toHex()
                 this.alias = alias
                 indexName?.takeIf { it.isNotBlank() }?.let{ this.indexName = it }
@@ -104,5 +106,6 @@ class AffiliateRecord(id: EntityID<String>): Entity<String>(id) {
     var serviceKeys by ServiceAccountRecord via AffiliateToServiceTable
     val identities by AffiliateIdentityRecord referrersOn AffiliateIdentityTable.publicKey
     var keyUuid by AffiliateTable.keyUuid
+    var encryptionKeyUuid by AffiliateTable.encryptionKeyUuid
     var authPublicKey by AffiliateTable.authPublicKey
 }

--- a/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/domain/Key.kt
+++ b/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/domain/Key.kt
@@ -1,0 +1,6 @@
+package io.provenance.p8e.shared.domain
+
+import java.security.PublicKey
+import java.util.*
+
+data class ExternalKeyRef(val uuid: UUID, val publicKey: PublicKey)

--- a/p8e-util/src/main/kotlin/io/p8e/crypto/SmartKeySigner.kt
+++ b/p8e-util/src/main/kotlin/io/p8e/crypto/SmartKeySigner.kt
@@ -47,8 +47,10 @@ import java.security.spec.X509EncodedKeySpec
  * SmartKey is designed to enable businesses to serve key management needs for all their applications, whether they are
  * operating in a public, private, or hybrid cloud.
  */
-
-class SmartKeySigner: SignerImpl {
+class SmartKeySigner(
+    private val signAndVerifyApi: SignAndVerifyApi,
+    private val securityObjectsApi: SecurityObjectsApi,
+): SignerImpl {
 
     init {
         Security.addProvider(BouncyCastleProvider())
@@ -131,7 +133,7 @@ class SmartKeySigner: SignerImpl {
         return signature?.verify(signatureBytes)!!
     }
 
-    override fun sign(): ByteArray = SignAndVerifyApi().sign(keyUuid, signatureRequest).signature
+    override fun sign(): ByteArray = signAndVerifyApi.sign(keyUuid, signatureRequest).signature
 
     override fun sign(data: String): Common.Signature = sign(data.toByteArray())
 
@@ -143,7 +145,7 @@ class SmartKeySigner: SignerImpl {
             .data(data)
             .deterministicSignature(true)
 
-        val signatureResponse = SignAndVerifyApi().sign(keyUuid, signatureRequest)
+        val signatureResponse = signAndVerifyApi.sign(keyUuid, signatureRequest)
 
         return ProtoUtil
             .signatureBuilderOf(String(signatureResponse.signature.base64Encode()))
@@ -188,5 +190,5 @@ class SmartKeySigner: SignerImpl {
      *
      * @return [PublicKey] return the Java security version of the PublicKey.
      */
-    override fun getPublicKey(): PublicKey = SecurityObjectsApi().getSecurityObject(keyUuid).toJavaPublicKey()
+    override fun getPublicKey(): PublicKey = securityObjectsApi.getSecurityObject(keyUuid).toJavaPublicKey()
 }

--- a/p8e-util/src/main/kotlin/io/p8e/crypto/SmartKeySigner.kt
+++ b/p8e-util/src/main/kotlin/io/p8e/crypto/SmartKeySigner.kt
@@ -188,10 +188,5 @@ class SmartKeySigner: SignerImpl {
      *
      * @return [PublicKey] return the Java security version of the PublicKey.
      */
-    override fun getPublicKey(): PublicKey {
-        val smPublicKey = SecurityObjectsApi().getSecurityObject(keyUuid).pubKey
-        val x509PublicKey = KeyFactory.getInstance("EC").generatePublic(X509EncodedKeySpec(smPublicKey))
-        val bcPublicKey = BCECPublicKey(x509PublicKey as ECPublicKey, BouncyCastlePQCProvider.CONFIGURATION)
-        return bcPublicKey.toHex().toJavaPublicKey()
-    }
+    override fun getPublicKey(): PublicKey = SecurityObjectsApi().getSecurityObject(keyUuid).toJavaPublicKey()
 }

--- a/p8e-util/src/main/kotlin/io/p8e/util/CryptoExtensions.kt
+++ b/p8e-util/src/main/kotlin/io/p8e/util/CryptoExtensions.kt
@@ -1,10 +1,16 @@
 package io.p8e.util
 
+import com.fortanix.sdkms.v1.model.KeyObject
 import io.p8e.proto.PK
 import io.provenance.p8e.encryption.ecies.ECUtils
+import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey
+import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider
 import org.bouncycastle.util.encoders.Hex
+import java.security.KeyFactory
 import java.security.PrivateKey
 import java.security.PublicKey
+import java.security.interfaces.ECPublicKey
+import java.security.spec.X509EncodedKeySpec
 
 fun PK.PublicKey.toPublicKey(): PublicKey =
     this.let {
@@ -28,7 +34,14 @@ fun PublicKey.toSha512Hex() = toHex().hexStringToByteArray().sha512().toHexStrin
 
 fun String.toJavaPublicKey() = toPublicKeyProto().toPublicKey()
 
+fun KeyObject.toJavaPublicKey() = pubKey
+    .let { KeyFactory.getInstance("EC").generatePublic(X509EncodedKeySpec(it)) }
+    .let { BCECPublicKey(it as ECPublicKey, BouncyCastlePQCProvider.CONFIGURATION) }
+    .toPublicKeyProto().toPublicKey()
+
 fun String.toPublicKeyProto(): PK.PublicKey = PK.PublicKey.parseFrom(Hex.decode(this))
+
+fun ByteArray.toPublicKeyProto(): PK.PublicKey = PK.PublicKey.parseFrom(this)
 
 fun PK.PrivateKey.toPrivateKey(): PrivateKey =
     this.let {


### PR DESCRIPTION
- Working adding affiliates using either database or smart key provider 
  - Both keys have the APPMANAGEABLE operation set so we can update them programmatically (i.e. change name, etc.)
  - Signing key can sign/verify only
  - Encryption key has the AGREEKEY operation so it can be used for the diffie-hellman key agreement used for the encryption process w/ object-store 🤞 
- Working edit of Affiliate alias being reflected in SmartKey
- If there is an error during smartKey affiliate creation (either generating a key, or something database related), any generated keys are deleted, so as to not leave orphaned keys hanging out in SmartKey