### PR TITLE
fix contract spec -> scope mapping for contract jars with multiple contracts

### DIFF
--- a/p8e-migration/sql/V68__Update_Contract_Spec_Mapping_Index.sql
+++ b/p8e-migration/sql/V68__Update_Contract_Spec_Mapping_Index.sql
@@ -1,0 +1,2 @@
+DROP INDEX contract_spec_hash_scope_unq_idx;
+CREATE UNIQUE INDEX contract_spec_hash_scope_unq_idx ON contract_spec_mapping (hash,scope_specification_uuid,provenance_hash);


### PR DESCRIPTION
- the contract bootstrapping was relying on this index filtering out duplicate contract spec hashes for submission with scope specifications... however, now that the chain is actually checking the spec->contract mapping (https://github.com/provenance-io/provenance/pull/322), this will break scope specifications for contract jars containing multiple contracts
- adding in the provenance_hash (hash of the contract spec proto itself) to the unique index allows for this to work