### PR TITLE
Add optional gas multiplier config to allow for increased fee distribution

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/config/Properties.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/config/Properties.kt
@@ -62,6 +62,8 @@ class ChaincodeProperties {
     @NotNull var mainNet: Boolean = false
     @NotNull var emptyIterationBackoffMS: Int = 1_000
     @NotNull var txBatchSize: Int = 25
+    @NotNull var gasMultiplier: Double = 1.0
+    @NotNull var maxGasMultiplierPerDay: Int = 1000
 }
 
 @ConfigurationProperties(prefix = "redis")

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
@@ -62,11 +62,10 @@ class ChaincodeInvokeService(
     private var gasMultiplierResetAt = OffsetDateTime.now()
     private var gasMultiplierDailyCount = 0
         get() {
-            val now = OffsetDateTime.now()
-            if (gasMultiplierResetAt.plusDays(1) < now) {
+            if (gasMultiplierResetAt.plusDays(1) < OffsetDateTime.now()) {
                 log.info("resetting gasMultiplier daily count to 0")
                 field = 0
-                gasMultiplierResetAt = now
+                gasMultiplierResetAt = gasMultiplierResetAt.plusDays(1)
             }
             return field
         }

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
@@ -26,6 +26,7 @@ import io.provenance.p8e.shared.domain.ScopeSpecificationRecord
 import io.provenance.pbc.clients.*
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.springframework.stereotype.Component
+import java.time.OffsetDateTime
 import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Future
@@ -56,6 +57,19 @@ class ChaincodeInvokeService(
     private val indexRegex = "^.*message index: (\\d+).*$".toRegex()
 
     private val accountInfo = provenanceGrpc.accountInfo()
+
+    // Optional gas multiplier tracking
+    private var gasMultiplierResetAt = OffsetDateTime.now()
+    private var gasMultiplierDailyCount = 0
+        get() {
+            val now = OffsetDateTime.now()
+            if (gasMultiplierResetAt.plusDays(1) < now) {
+                log.info("resetting gasMultiplier daily count to 0")
+                field = 0
+                gasMultiplierResetAt = now
+            }
+            return field
+        }
 
     // private val queue = ConcurrentHashMap<UUID, BlockchainTransaction>()
 
@@ -402,8 +416,15 @@ class ChaincodeInvokeService(
         val accountNumber = accountInfo.accountNumber
         val sequenceNumber = getAndIncrementSequenceNumber()
 
-
         val estimate = provenanceGrpc.estimateTx(body, accountNumber, sequenceNumber)
+
+        if (gasMultiplierDailyCount < chaincodeProperties.maxGasMultiplierPerDay) {
+            log.info("setting gasMultiplier to ${chaincodeProperties.gasMultiplier} (current count = $gasMultiplierDailyCount)")
+            estimate.setGasMultiplier(chaincodeProperties.gasMultiplier)
+            gasMultiplierDailyCount++
+        } else {
+            log.info("skipping gasMultiplier due to daily limit")
+        }
 
         return provenanceGrpc.batchTx(body, accountNumber, sequenceNumber, estimate)
     }

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ProvenanceGrpcService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ProvenanceGrpcService.kt
@@ -23,6 +23,7 @@ import io.provenance.engine.crypto.PbSigner
 import io.provenance.engine.util.toP8e
 import io.provenance.metadata.v1.ContractSpecificationRequest
 import io.provenance.metadata.v1.ScopeRequest
+import io.provenance.p8e.shared.extension.logger
 import io.provenance.p8e.shared.service.AffiliateService
 import io.provenance.pbc.clients.roundUp
 import org.kethereum.crypto.getCompressedPublicKey
@@ -187,7 +188,12 @@ data class GasEstimate(val estimate: Long, val feeAdjustment: Double? = DEFAULT_
     }
 
     private val adjustment = feeAdjustment ?: DEFAULT_FEE_ADJUSTMENT
+    private var gasMultiplier = 1.0
 
-    val limit = (estimate * adjustment).roundUp()
-    val fees = (limit * DEFAULT_GAS_PRICE).roundUp()
+    fun setGasMultiplier(multiplier: Double) { gasMultiplier = multiplier }
+
+    val limit
+        get() = (estimate * adjustment * gasMultiplier).roundUp()
+    val fees
+        get() = (limit * DEFAULT_GAS_PRICE).roundUp()
 }

--- a/p8e-api/src/main/resources/application-container.properties
+++ b/p8e-api/src/main/resources/application-container.properties
@@ -49,6 +49,8 @@ chaincode.chainId=${CHAINCODE_CHAIN_ID}
 chaincode.mnemonic=${CHAINCODE_MNEMONIC}
 chaincode.emptyIterationBackoffMS=${CHAINCODE_EMPTY_ITERATION_BACKOFF:750}
 chaincode.txBatchSize=${CHAINCODE_TX_BATCH_SIZE:25}
+chaincode.gasMultiplier=${CHAINCODE_GAS_MULTIPLIER:1.0}
+chaincode.maxGasMultiplierPerDay=${CHAINCODE_MAX_GAS_MULTIPLIER_PER_DAY:1000}
 
 # Redis
 redis.host=${REDIS_HOST}


### PR DESCRIPTION
* Default multiplier is 1.0, so this has no effect unless configured to do so
* Can set maximum number of gas multiples per day, default is 1000, count resets every 24 hours after startup time (just in-memory tracking, nothing fancy)