### PR TITLE
get client ip in grpc interceptor and log on EnvelopeEventObserver connect

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/grpc/interceptors/JwtServerInterceptor.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/grpc/interceptors/JwtServerInterceptor.kt
@@ -30,8 +30,11 @@ class JwtServerInterceptor(
             return object: ServerCall.Listener<ReqT>() {}
         }
 
+        val clientIp = call.attributes.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR)
+
         val context = Context.current()
             .withValue(Constant.PUBLIC_KEY_CTX, publicKey)
+            .withValue(Constant.CLIENT_IP_CTX, clientIp.toString())
 
         return Contexts.interceptCall(context, call, headers, next)
     }

--- a/p8e-api/src/main/kotlin/io/provenance/engine/grpc/observers/EnvelopeEventObserver.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/grpc/observers/EnvelopeEventObserver.kt
@@ -1,6 +1,7 @@
 package io.provenance.engine.grpc.observers
 
 import io.grpc.stub.StreamObserver
+import io.p8e.grpc.clientIp
 import io.p8e.grpc.observers.CompleteState
 import io.p8e.grpc.observers.EndState
 import io.p8e.grpc.observers.ExceptionState
@@ -167,6 +168,8 @@ class EnvelopeEventObserver(
 
     private fun connect(value: EnvelopeEvent): QueueingStreamObserverSender<EnvelopeEvent> {
         val publicKey = if(value.publicKey.hasEncryptionPublicKey()) value.publicKey.encryptionPublicKey.toPublicKey() else value.publicKey.signingPublicKey.toPublicKey()
+
+        logger().info("Connecting [publicKey = ${publicKey.toHex()}, classname = ${value.classname}, action = ${value.action}, ip = ${clientIp()}]")
 
         val streamObserver = timed("affiliate_connect") {
             transaction {

--- a/p8e-api/src/main/kotlin/io/provenance/engine/grpc/observers/EnvelopeEventObserver.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/grpc/observers/EnvelopeEventObserver.kt
@@ -169,7 +169,7 @@ class EnvelopeEventObserver(
     private fun connect(value: EnvelopeEvent): QueueingStreamObserverSender<EnvelopeEvent> {
         val publicKey = if(value.publicKey.hasEncryptionPublicKey()) value.publicKey.encryptionPublicKey.toPublicKey() else value.publicKey.signingPublicKey.toPublicKey()
 
-        logger().info("Connecting [publicKey = ${publicKey.toHex()}, classname = ${value.classname}, action = ${value.action}, ip = ${clientIp()}]")
+        logger().debug("Connecting [publicKey = ${publicKey.toHex()}, classname = ${value.classname}, action = ${value.action}, ip = ${clientIp()}]")
 
         val streamObserver = timed("affiliate_connect") {
             transaction {

--- a/p8e-api/src/main/kotlin/io/provenance/engine/grpc/observers/EnvelopeEventObserver.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/grpc/observers/EnvelopeEventObserver.kt
@@ -169,8 +169,6 @@ class EnvelopeEventObserver(
     private fun connect(value: EnvelopeEvent): QueueingStreamObserverSender<EnvelopeEvent> {
         val publicKey = if(value.publicKey.hasEncryptionPublicKey()) value.publicKey.encryptionPublicKey.toPublicKey() else value.publicKey.signingPublicKey.toPublicKey()
 
-        logger().debug("Connecting [publicKey = ${publicKey.toHex()}, classname = ${value.classname}, action = ${value.action}, ip = ${clientIp()}]")
-
         val streamObserver = timed("affiliate_connect") {
             transaction {
                 // Verify that this is a known affiliate
@@ -191,7 +189,7 @@ class EnvelopeEventObserver(
                 affiliateConnection.lastHeartbeat = OffsetDateTime.now()
             }
 
-            logger().debug("GRPC Connected: Affiliate ${queuerKey!!.publicKey.toHex()} Class ${queuerKey!!.classname}")
+            logger().debug("GRPC Connected: [affiliate = ${queuerKey!!.publicKey.toHex()}, classname = ${queuerKey!!.classname}, action = ${value.action}, ip = ${clientIp()}]")
 
             connectedKey.set(publicKey.toPublicKeyProto())
             queuers.computeIfAbsent(queuerKey!!) {

--- a/p8e-common/src/main/kotlin/io/p8e/grpc/Constant.kt
+++ b/p8e-common/src/main/kotlin/io/p8e/grpc/Constant.kt
@@ -10,12 +10,14 @@ import io.p8e.util.toJavaPublicKey
 object Constant {
     val JWT_ALGORITHM = "SHA256withECDSA"
     val PUBLIC_KEY_CTX = Context.key<String>("public-key")
+    val CLIENT_IP_CTX = Context.key<String>("client-ip")
     val JWT_METADATA_KEY = Metadata.Key.of("jwt", Metadata.ASCII_STRING_MARSHALLER)
     val JWT_CTX_KEY = Context.key<String>("jwt")
     val MAX_MESSAGE_SIZE = 200 * 1024 * 1024
 }
 
 fun publicKey() = Constant.PUBLIC_KEY_CTX.get().toJavaPublicKey()
+fun clientIp() = Constant.CLIENT_IP_CTX.get()
 
 fun <T: Message> T.complete(observer: StreamObserver<T>) {
     observer.onNext(this)


### PR DESCRIPTION
- Might be helpful in tracking down weird connection issues (i.e. determining if two different services are trying to watch with the same key/contract combo)