### PR TITLE
Add group id when generating SmartKey keys

### DIFF
--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/service/KeyManagementService.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/service/KeyManagementService.kt
@@ -5,7 +5,7 @@ import com.fortanix.sdkms.v1.model.*
 import io.p8e.util.toJavaPublicKey
 import io.p8e.util.toUuidProv
 import io.provenance.p8e.encryption.model.ExternalKeyRef
-import io.provenance.p8e.shared.extension.logger
+import io.provenance.p8e.shared.config.SmartKeyProperties
 import org.springframework.stereotype.Service
 import java.security.KeyPair
 import java.util.*
@@ -16,12 +16,16 @@ enum class KeyUsageType(val options: List<KeyOperations>) {
 }
 
 @Service
-class KeyManagementService(private val securityObjectsApi: SecurityObjectsApi) {
+class KeyManagementService(
+    private val securityObjectsApi: SecurityObjectsApi,
+    private val smartKeyProperties: SmartKeyProperties
+) {
     fun importKey(keyPair: KeyPair, name: String?, keyUsageType: KeyUsageType): ExternalKeyRef =
         importOrGenerateKey(SobjectRequest()
             .objType(ObjectType.EC)
             .value(keyPair.private.encoded)
             .keyOps(keyUsageType.options)
+            .groupId(smartKeyProperties.groupId)
             .name(name)
         )
 
@@ -30,6 +34,7 @@ class KeyManagementService(private val securityObjectsApi: SecurityObjectsApi) {
             .objType(ObjectType.EC)
             .ellipticCurve(EllipticCurve.SECP256K1)
             .keyOps(keyUsageType.options)
+            .groupId(smartKeyProperties.groupId)
             .name(name)
         )
 

--- a/p8e-api-webservice/src/main/resources/application-container.properties
+++ b/p8e-api-webservice/src/main/resources/application-container.properties
@@ -44,3 +44,4 @@ provenance.keystone.url=${PROVENANCE_KEYSTONE_URL}
 
 # Smart Key
 smartkey.apikey=${SMARTKEY_API_KEY}
+smartkey.group-id=${SMARTKEY_GROUP_ID}

--- a/p8e-api-webservice/src/main/resources/application-development.properties
+++ b/p8e-api-webservice/src/main/resources/application-development.properties
@@ -32,3 +32,4 @@ objectstore.key=
 
 # Smart Key
 smartkey.apikey=${SMARTKEY_API_KEY}
+smartkey.group-id=${SMARTKEY_GROUP_ID}

--- a/p8e-api-webservice/src/main/resources/application-local.properties
+++ b/p8e-api-webservice/src/main/resources/application-local.properties
@@ -43,3 +43,4 @@ provenance.keystone.url=https://test.provenance.io/keystone/key/registration/sec
 
 # Smart Key
 smartkey.apikey=${SMARTKEY_API_KEY}
+smartkey.group-id=${SMARTKEY_GROUP_ID}

--- a/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/config/Properties.kt
+++ b/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/config/Properties.kt
@@ -25,4 +25,5 @@ class ProvenanceKeystoneProperties {
 @ConfigurationProperties(prefix = "smartkey")
 class SmartKeyProperties {
     var apiKey: String? = null
+    var groupId: String? = null
 }


### PR DESCRIPTION
Need to add the group id when generating security objects for groups (affiliates) that either belong to prod or test