### PR TITLE
Keep a consistent signing and verification method for both SmartKey a…

### DIFF
--- a/p8e-engine/src/main/kotlin/io/p8e/engine/ContractWrapper.kt
+++ b/p8e-engine/src/main/kotlin/io/p8e/engine/ContractWrapper.kt
@@ -13,8 +13,6 @@ import io.provenance.p8e.encryption.model.KeyRef
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import java.lang.reflect.Parameter
-import java.security.KeyPair
-import java.security.PublicKey
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutorService
 import kotlin.concurrent.thread

--- a/p8e-util/src/main/kotlin/io/p8e/crypto/Pen.kt
+++ b/p8e-util/src/main/kotlin/io/p8e/crypto/Pen.kt
@@ -66,7 +66,8 @@ class Pen(
 
     override fun sign(): ByteArray {
         signature.update(aggregatedData)
-        return signature.sign()
+        // null out the aggregatedData value to reset for next verify/sign
+        return signature.sign().also { aggregatedData = null }
     }
 
     override fun update(data: ByteArray) = signature.update(data)
@@ -85,7 +86,6 @@ class Pen(
                  */
                 if(objSizeIndexer == OBJECT_SIZE_BYTES) {
                     objSizeIndexer = (off + res)
-                    aggregatedData = null
                     aggregatedData = if (aggregatedData == null) {
                         data.copyOfRange(off, off + res)
                     } else {
@@ -104,19 +104,19 @@ class Pen(
     override fun verify(signatureBytes: ByteArray): Boolean {
         signature.update(aggregatedData)
 
-        // Reset the object size indexer.
-        objSizeIndexer = OBJECT_SIZE_BYTES
+        // Reset the object size indexer and null out the aggregatedData value.
+        objSizeIndexer = OBJECT_SIZE_BYTES.also { aggregatedData = null }
 
         return signature.verify(signatureBytes)
     }
 
     override fun initVerify(publicKey: PublicKey) {
-        signature.apply { initVerify(publicKey) }
+        signature.initVerify(publicKey)
         verifying = true
     }
 
     override fun initSign() {
-        signature.apply { initSign(keyPair.private) }
+        signature.initSign(keyPair.private)
         verifying = false
     }
 

--- a/p8e-util/src/main/kotlin/io/p8e/crypto/Pen.kt
+++ b/p8e-util/src/main/kotlin/io/p8e/crypto/Pen.kt
@@ -1,6 +1,9 @@
 package io.p8e.crypto
 
 import com.google.protobuf.Message
+import io.p8e.crypto.SignerImpl.Companion.OBJECT_SIZE_BYTES
+import io.p8e.crypto.SignerImpl.Companion.PROVIDER
+import io.p8e.crypto.SignerImpl.Companion.SIGN_ALGO
 import io.p8e.proto.Common
 import io.p8e.proto.PK
 import io.p8e.proto.ProtoUtil
@@ -16,13 +19,6 @@ class Pen(
     private val keyPair: KeyPair
 ): SignerImpl {
 
-    companion object {
-        // Algo must match Provenance-object-store
-        val SIGN_ALGO = "SHA512withECDSA"
-        val KEY_TYPE = "ECDSA"
-        val PROVIDER = BouncyCastleProvider.PROVIDER_NAME
-    }
-
     val privateKey: PrivateKey = keyPair.private
 
     val signature: Signature = Signature.getInstance(
@@ -33,6 +29,10 @@ class Pen(
     init {
         Security.addProvider(BouncyCastleProvider())
     }
+
+    private var verifying: Boolean = false
+    private var objSizeIndexer: Int = OBJECT_SIZE_BYTES
+    private var aggregatedData: ByteArray? = null
 
     /**
      * Return the signing public key.
@@ -64,19 +64,61 @@ class Pen(
             .orThrow { IllegalStateException("can't verify signature - public cert may not match private key.") }
     }
 
-    override fun sign(): ByteArray = signature.sign()
+    override fun sign(): ByteArray {
+        signature.update(aggregatedData)
+        return signature.sign()
+    }
 
-    override fun update(data: ByteArray) { signature.update(data) }
+    override fun update(data: ByteArray) = signature.update(data)
 
-    override fun update(data: ByteArray, off: Int, len: Int) { signature.update(data, off, len) }
+    override fun update(data: ByteArray, off: Int, res: Int) {
+        // If off is less then res, these are the data that we care about.
+        if(off < res) {
+            if(!verifying) {
+                val dataSample = data.copyOfRange(off, off+res)
+                aggregatedData = dataSample
+            } else {
+                /**
+                 * The downstream (data verification) chunks the data into data size of 8192.
+                 * The data needs to be aggregated to its signing size of 32768 before the
+                 * data can be validated.
+                 */
+                if(objSizeIndexer == OBJECT_SIZE_BYTES) {
+                    objSizeIndexer = (off + res)
+                    aggregatedData = null
+                    aggregatedData = if (aggregatedData == null) {
+                        data.copyOfRange(off, off + res)
+                    } else {
+                        aggregatedData?.plus(data.copyOfRange(off, off + res))
+                    }
+                } else {
+                    objSizeIndexer += (off + res)
+                    aggregatedData = aggregatedData?.plus(data.copyOfRange(off, off + res))
+                }
+            }
+        }
+    }
 
     override fun update(data: Byte) { signature.update(data) }
 
-    override fun verify(signatureBytes: ByteArray): Boolean = signature.verify(signatureBytes)
+    override fun verify(signatureBytes: ByteArray): Boolean {
+        signature.update(aggregatedData)
 
-    override fun initVerify(publicKey: PublicKey) { signature.apply { initVerify(publicKey) } }
+        // Reset the object size indexer.
+        objSizeIndexer = OBJECT_SIZE_BYTES
 
-    override fun initSign() { signature.apply { initSign(keyPair.private) } }
+        return signature.verify(signatureBytes)
+    }
+
+    override fun initVerify(publicKey: PublicKey) {
+        signature.apply { initVerify(publicKey) }
+        verifying = true
+    }
+
+    override fun initSign() {
+        signature.apply { initSign(keyPair.private) }
+        verifying = false
+    }
 
     override fun verify(data: ByteArray, signature: Common.Signature): Boolean =
         Signature.getInstance(signature.algo, signature.provider)

--- a/p8e-util/src/main/kotlin/io/p8e/crypto/SignerImpl.kt
+++ b/p8e-util/src/main/kotlin/io/p8e/crypto/SignerImpl.kt
@@ -3,10 +3,19 @@ package io.p8e.crypto
 import com.google.protobuf.Message
 import io.p8e.proto.Common
 import io.p8e.proto.PK
+import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.PublicKey
-import java.security.Signature
-
 interface SignerImpl {
+
+    companion object{
+        // Algo must match Provenance-object-store
+        val SIGN_ALGO = "SHA512withECDSA"
+        val PROVIDER = BouncyCastleProvider.PROVIDER_NAME
+
+        //The size of the object bytes that are signed at bootstrap time is 32768.
+        //The data pulled from the dime input stream breaks the data into chunks of 8192.
+        val OBJECT_SIZE_BYTES = 8192 * 4
+    }
 
     /**
      * signer function implementation will be done by specific signers.

--- a/p8e-util/src/main/kotlin/io/p8e/crypto/SmartKeySigner.kt
+++ b/p8e-util/src/main/kotlin/io/p8e/crypto/SmartKeySigner.kt
@@ -5,6 +5,9 @@ import com.fortanix.sdkms.v1.api.SignAndVerifyApi
 import com.fortanix.sdkms.v1.model.DigestAlgorithm
 import com.fortanix.sdkms.v1.model.SignRequest
 import com.google.protobuf.Message
+import io.p8e.crypto.SignerImpl.Companion.OBJECT_SIZE_BYTES
+import io.p8e.crypto.SignerImpl.Companion.PROVIDER
+import io.p8e.crypto.SignerImpl.Companion.SIGN_ALGO
 import io.p8e.proto.Common
 import io.p8e.proto.PK
 import io.p8e.proto.ProtoUtil
@@ -48,16 +51,6 @@ class SmartKeySigner(
 
     init {
         Security.addProvider(BouncyCastleProvider())
-    }
-
-    companion object {
-        // Algo must match Provenance-object-store
-        val SIGN_ALGO = "SHA512withECDSA"
-        val PROVIDER = BouncyCastleProvider.PROVIDER_NAME
-
-        //The size of the object bytes that are signed at bootstrap time is 32768.
-        //The data pulled from the dime input stream breaks the data into chunks of 8192.
-        val OBJECT_SIZE_BYTES = 8192 * 4
     }
 
     private var signature: Signature? = null

--- a/p8e-util/src/main/kotlin/io/p8e/proto/ProtoUtil.kt
+++ b/p8e-util/src/main/kotlin/io/p8e/proto/ProtoUtil.kt
@@ -4,6 +4,8 @@ import com.google.protobuf.Message
 import com.google.protobuf.Message.Builder
 import com.google.protobuf.util.JsonFormat
 import io.p8e.crypto.Pen
+import io.p8e.crypto.SignerImpl.Companion.PROVIDER
+import io.p8e.crypto.SignerImpl.Companion.SIGN_ALGO
 import io.p8e.proto.Common.DefinitionSpec
 import io.p8e.proto.Common.DefinitionSpec.Type
 import io.p8e.proto.Common.Location
@@ -62,8 +64,8 @@ object ProtoUtil {
 
     fun signatureBuilderOf(signature: String): Signature.Builder =
         Signature.newBuilder()
-            .setAlgo(Pen.SIGN_ALGO)
-            .setProvider(Pen.PROVIDER)
+            .setAlgo(SIGN_ALGO)
+            .setProvider(PROVIDER)
             .setSignature(signature)
 
 


### PR DESCRIPTION
**Context:** This fixes a bug that occurs at the time of bootstrapping for mix affiliates of SmartKey and Database. Before the objects gets pushed to OS, they are signed with the bootstrapping key, in this particular case is an Affiliate with a Database key management type. When executing a contract for a key management type SmartKey, this would fail to retrieve the objects from OS due to signature verification failure, but would retrieve fine with a Database key management type, and cache accordingly, so if the SmartKey affiliate were to run again the next time, it would succeed cause of the cached objects, but if p8e-api were to restart and have that cache cleared that Affiliate with the SmartKey key management type would fail.

**Fix:** Unified the way we signed and verified objects for both SmartKey and Pen class.