### PR TITLE
added loadContract overload for finer control over contract object

### DIFF
--- a/p8e-sdk/src/main/kotlin/io/p8e/ContractManager.kt
+++ b/p8e-sdk/src/main/kotlin/io/p8e/ContractManager.kt
@@ -334,7 +334,7 @@ class ContractManager(
      *
      * @param contractClazz subclass of P8eContract that represents the original contract
      * @param executionUuid the execution id of the original contract
-     * @param isFragment flag identifying if the original contract execution was requested (true) or initiated (false)
+     * @param isFragment flag identifying whether this contract is to be a response to a previous execution request (true) or a new execution (false)
      */
     fun <T: P8eContract> loadContract(
         contractClazz: Class<T>,
@@ -354,8 +354,8 @@ class ContractManager(
 
     /**
      * Returns a new Contract object that can be configured and executed. This Contract represents a contract
-     * based on a previously executed Contract that did not complete successfully. The envelope will contain
-     * a different execution uuid than was originally associated with the Envelope when it failed execution.
+     * based on a previously executed Contract that completed successfully. The envelope will contain
+     * a different execution uuid than was originally associated with the Envelope when it completed execution.
      *
      * @param contractClazz subclass of P8eContract that represents the original contract
      * @param executionUuid the execution id of the original contract

--- a/p8e-sdk/src/main/kotlin/io/p8e/ContractManager.kt
+++ b/p8e-sdk/src/main/kotlin/io/p8e/ContractManager.kt
@@ -328,17 +328,45 @@ class ContractManager(
 //            }
 //    }
 
+
+    /**
+     * Returns an existing Contract object that can be configured and executed.
+     *
+     * @param contractClazz subclass of P8eContract that represents the original contract
+     * @param executionUuid the execution id of the original contract
+     * @param isFragment flag identifying if the original contract execution was requested (true)
+     */
     fun <T: P8eContract> loadContract(
-        clazz: Class<T>,
-        executionUuid: UUID
+        contractClazz: Class<T>,
+        executionUuid: UUID,
+        isFragment: Boolean
     ): Contract<T> {
         return Contract(
             this,
             client,
-            dehydrateSpec(clazz),
+            dehydrateSpec(contractClazz),
             client.getContract(executionUuid),
-            clazz,
-            contractClassExecutor(clazz),
+            contractClazz,
+            contractClassExecutor(contractClazz),
+            isFragment
+        )
+    }
+
+    /**
+     * Returns a new Contract object that can be configured and executed. This Contract represents a contract
+     * based on a previously executed Contract that did not complete successfully. The envelope will contain
+     * a different execution uuid than was originally associated with the Envelope when it failed execution.
+     *
+     * @param contractClazz subclass of P8eContract that represents the original contract
+     * @param executionUuid the execution id of the original contract
+     */
+    fun <T: P8eContract> loadContract(
+        contractClazz: Class<T>,
+        executionUuid: UUID
+    ): Contract<T> {
+        return loadContract(
+            contractClazz,
+            executionUuid,
             false
         ).also {
             it.newExecution()

--- a/p8e-sdk/src/main/kotlin/io/p8e/ContractManager.kt
+++ b/p8e-sdk/src/main/kotlin/io/p8e/ContractManager.kt
@@ -334,7 +334,7 @@ class ContractManager(
      *
      * @param contractClazz subclass of P8eContract that represents the original contract
      * @param executionUuid the execution id of the original contract
-     * @param isFragment flag identifying if the original contract execution was requested (true)
+     * @param isFragment flag identifying if the original contract execution was requested (true) or initiated (false)
      */
     fun <T: P8eContract> loadContract(
         contractClazz: Class<T>,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
The ability to load and execute requested (fragment) contracts was required.  This PR contains an overload to `loadContract` with this increased flexibility.

## Files most critical to review
`p8e-sdk/src/main/kotlin/io/p8e/ContractManager.kt`