### PR TITLE
Fix for NPE signature

### DIFF
--- a/p8e-util/src/main/kotlin/io/p8e/crypto/Pen.kt
+++ b/p8e-util/src/main/kotlin/io/p8e/crypto/Pen.kt
@@ -65,7 +65,11 @@ class Pen(
     }
 
     override fun sign(): ByteArray {
-        signature.update(aggregatedData)
+        // Only update if the aggregated data is not null
+        if(aggregatedData != null) {
+            signature.update(aggregatedData)
+        }
+
         // null out the aggregatedData value to reset for next verify/sign
         return signature.sign().also { aggregatedData = null }
     }


### PR DESCRIPTION
Leaving as a draft as there can be different resolutions.

After discussing with Pierce, it is highly possible that we received an invalid input from the stream. 

As the client side stacktrace shows that there was an attempt to build facts and it has been known that contracts are built with null facts:

```
        at io.p8e.engine.ContractWrapper.toFactInstance(ContractWrapper.kt:132)
	at io.p8e.engine.ContractWrapper.buildFacts(ContractWrapper.kt:105)
	at io.p8e.engine.ContractWrapper.<init>(ContractWrapper.kt:29)
```

Thus receiving NPE at signature update time, when testing with HelloWorld contracts this error didn't come about.

Solutions:
1. Wrap the signature update as in this PR shows and let it error out eventually in the execution lifecycle.
2. Let the client know at this point P8e received invalid/null stuff to sign.

