### PR TITLE
look up scope specification name on chain vs. db

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ProvenanceGrpcService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ProvenanceGrpcService.kt
@@ -17,18 +17,21 @@ import io.p8e.engine.threadedMap
 import io.p8e.proto.ContractScope
 import io.p8e.util.ThreadPoolFactory
 import io.p8e.util.toByteString
+import io.p8e.util.toUuidProv
 import io.provenance.engine.config.ChaincodeProperties
 import io.provenance.engine.crypto.Account
 import io.provenance.engine.crypto.PbSigner
 import io.provenance.engine.util.toP8e
 import io.provenance.metadata.v1.ContractSpecificationRequest
 import io.provenance.metadata.v1.ScopeRequest
-import io.provenance.p8e.shared.extension.logger
+import io.provenance.metadata.v1.ScopeSpecification
+import io.provenance.metadata.v1.ScopeSpecificationRequest
 import io.provenance.p8e.shared.service.AffiliateService
 import io.provenance.pbc.clients.roundUp
 import org.kethereum.crypto.getCompressedPublicKey
 import org.springframework.stereotype.Service
 import java.net.URI
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -169,8 +172,15 @@ class ProvenanceGrpcService(
                 ).contractSpecification.specification.hash
             }.toMap()
 
-        return scopeResponse.toP8e(contractSpecHashLookup, affiliateService)
+        val scopeSpecificationName = getScopeSpecification(scopeResponse.scope.scopeSpecIdInfo.scopeSpecUuid.toUuidProv()).description.name
+
+        return scopeResponse.toP8e(contractSpecHashLookup, scopeSpecificationName, affiliateService)
     }
+
+    fun getScopeSpecification(uuid: UUID): ScopeSpecification = metadataQueryService.scopeSpecification(ScopeSpecificationRequest.newBuilder()
+            .setSpecificationId(uuid.toString())
+            .build()
+        ).scopeSpecification.specification
 }
 
 fun Collection<Message>.toTxBody(): TxBody = TxBody.newBuilder()

--- a/p8e-api/src/main/kotlin/io/provenance/engine/util/ProvenanceProtoExtensions.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/util/ProvenanceProtoExtensions.kt
@@ -93,7 +93,7 @@ fun Envelope.toProv(invokerAddress: String): MsgP8eMemorializeContractRequest =
 
 // Extensions for marshalling data back to P8e
 
-fun ScopeResponse.toP8e(contractSpecHashLookup: Map<String, String>, affiliateService: AffiliateService): ContractScope.Scope = ContractScope.Scope.newBuilder()
+fun ScopeResponse.toP8e(contractSpecHashLookup: Map<String, String>, scopeSpecificationName: String, affiliateService: AffiliateService): ContractScope.Scope = ContractScope.Scope.newBuilder()
     .setUuid(scope.scopeIdInfo.scopeUuid.toProtoUuidProv())
     .addAllParties(scope.scope.ownersList.map { it.toP8e(affiliateService) })
     .addAllRecordGroup(sessionsList.map { session ->
@@ -110,7 +110,7 @@ fun ScopeResponse.toP8e(contractSpecHashLookup: Map<String, String>, affiliateSe
             .setAudit(session.session.audit.toP8e())
             .build()
     })
-    .setScopeSpecificationName(transaction { ScopeSpecificationRecord.findById(scope.scopeSpecIdInfo.scopeSpecUuid.toUuidProv())!!.name })
+    .setScopeSpecificationName(scopeSpecificationName)
     .setLastEvent(sessionsList.lastSession()?.let { session ->
         ContractScope.Event.newBuilder()
             .setExecutionUuid(Contracts.ContractState.parseFrom(session.session.context).executionUuid)


### PR DESCRIPTION
- fixes handling of events where scope specification not present in local p8e db (i.e. some other party)