### PR TITLE
Allow signing of empty data for SmartKey

### DIFF
--- a/p8e-util/src/main/kotlin/io/p8e/crypto/SmartKeySigner.kt
+++ b/p8e-util/src/main/kotlin/io/p8e/crypto/SmartKeySigner.kt
@@ -70,7 +70,11 @@ class SmartKeySigner(
      * Using SmartKey to sign data.
      */
     override fun initSign() {
-        signatureRequest = SignRequest().hashAlg(DigestAlgorithm.SHA512).deterministicSignature(true)
+        signatureRequest = SignRequest()
+            .hashAlg(DigestAlgorithm.SHA512)
+            .deterministicSignature(true)
+            .data(byteArrayOf())
+
         verifying = false
     }
 


### PR DESCRIPTION
Let SmartKey sign empty data, mirror what the java Signature class currently does, cause there are uses cases where data comes in as empty but still gets signed.