### PR TITLE
add in temporary logging around client reconnect to track down where things are dying

### DIFF
--- a/p8e-sdk/src/main/kotlin/io/p8e/async/Heartbeat.kt
+++ b/p8e-sdk/src/main/kotlin/io/p8e/async/Heartbeat.kt
@@ -89,7 +89,11 @@ class HeartbeatManagerRunnable(
 
             for (key in toAdd) {
                 val receiveObserver = desired.getValue(key).invoke()
-                val sendObserver = QueueingStreamObserverSender(manager.client.event(key.clazz, receiveObserver))
+                log.info("Fetched receiveObserver for ${key.publicKey.toHex() to key.clazz.name}")
+                val sendObserver = QueueingStreamObserverSender(manager.client.event(key.clazz, receiveObserver).also {
+                    log.info("Opened event stream for ${key.publicKey.toHex() to key.clazz.name}")
+                })
+                log.info("Initialized sendObserver for ${key.publicKey.toHex() to key.clazz.name}")
 
                 receiveObserver.setQueuer(sendObserver)
                 queuers[key.clazz] = sendObserver


### PR DESCRIPTION
We probably should just move this into main so it is present in future releases until we have figured out why sometimes reconnect seems to just hang. I don't think anyone has been reliably on the pre-release created from this branch