### PR TITLE
Ensure scope separate block

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Component
 import java.time.OffsetDateTime
 import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Future
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
@@ -52,14 +53,9 @@ class ChaincodeInvokeService(
     companion object {
         private val log = logger()
 
-        private val blockScopeIds = HashSet<String>()
-        private val scopeLockHeights = HashMap<String, Long>()
+        private val blockScopeIds = ConcurrentHashMap.newKeySet<String>()
+        private val scopeLockHeights = ConcurrentHashMap<String, Long>()
         private var currentBlockHeight = 0L
-
-        fun unlockScope(scopeUuid: String) {
-            blockScopeIds.remove(scopeUuid)
-            scopeLockHeights.remove(scopeUuid)
-        }
 
         private fun scopeLocked(scopeUuid: String): Boolean = blockScopeIds.contains(scopeUuid)
 
@@ -68,6 +64,11 @@ class ChaincodeInvokeService(
 
             blockScopeIds.add(scopeUuid)
             scopeLockHeights[scopeUuid] = currentBlockHeight
+        }
+
+        fun unlockScope(scopeUuid: String) {
+            blockScopeIds.remove(scopeUuid)
+            scopeLockHeights.remove(scopeUuid)
         }
 
         private fun logStaleScopeLocks() {

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/TransactionStatusService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/TransactionStatusService.kt
@@ -68,6 +68,7 @@ class TransactionStatusService(
 
             if (envelope.isInvoker ?: false) {
                 val event = envelope.uuid.value.toProtoUuidProv().toEvent(Event.ENVELOPE_CHAINCODE)
+                ChaincodeInvokeService.freeScope(envelope.scope.scopeUuid)
                 eventService.submitEvent(event, envelope.uuid.value)
             }
         }

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/TransactionStatusService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/TransactionStatusService.kt
@@ -11,7 +11,6 @@ import io.provenance.engine.grpc.v1.toEvent
 import io.provenance.p8e.shared.domain.EnvelopeRecord
 import io.provenance.p8e.shared.domain.EnvelopeTable
 import io.provenance.p8e.shared.state.EnvelopeStateEngine
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.inList
 import io.p8e.proto.ContractScope.Envelope.Status
 import io.p8e.proto.Events.P8eEvent.Event
 import org.springframework.stereotype.Component
@@ -68,7 +67,7 @@ class TransactionStatusService(
 
             if (envelope.isInvoker ?: false) {
                 val event = envelope.uuid.value.toProtoUuidProv().toEvent(Event.ENVELOPE_CHAINCODE)
-                ChaincodeInvokeService.freeScope(envelope.scope.scopeUuid)
+                ChaincodeInvokeService.unlockScope(envelope.scope.scopeUuid.toString())
                 eventService.submitEvent(event, envelope.uuid.value)
             }
         }

--- a/p8e-api/src/main/kotlin/io/provenance/engine/stream/ScopeStream.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/stream/ScopeStream.kt
@@ -136,7 +136,7 @@ class ScopeStream(
             EventStreamRecord.update(eventStreamId, blockHeight)
 
             events.forEach {
-                ChaincodeInvokeService.freeScope(it.scope.uuid.toUuidProv())
+                ChaincodeInvokeService.unlockScope(it.scope.uuid.value)
             }
         }
     }

--- a/p8e-api/src/main/kotlin/io/provenance/engine/stream/ScopeStream.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/stream/ScopeStream.kt
@@ -11,6 +11,7 @@ import io.p8e.util.toProtoUuidProv
 import io.provenance.engine.config.EventStreamProperties
 import io.provenance.engine.domain.EventStreamRecord
 import io.provenance.engine.domain.TransactionStatusRecord
+import io.provenance.engine.service.ChaincodeInvokeService
 import io.provenance.p8e.shared.index.data.IndexScopeRecord
 import io.provenance.engine.service.EventService
 import io.provenance.engine.service.ProvenanceGrpcService
@@ -133,6 +134,10 @@ class ScopeStream(
 
             // Mark that we've stored up to the given block height for indexing.
             EventStreamRecord.update(eventStreamId, blockHeight)
+
+            events.forEach {
+                ChaincodeInvokeService.freeScope(it.scope.uuid.toUuidProv())
+            }
         }
     }
 }


### PR DESCRIPTION
free specific scopes for further transactions, hopefully a more correct approach than just watching the block height and clearing all scope ids upon an increase in height. This should prevent the same scope from having a contract run on it in different transactions in the same block, which can cause events to remain unprocessed, due to the scope.lastEvent being used to look up envelopes based on execution uuid