### PR TITLE
Improve search and allow for disabling object fetching

### DIFF
--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/config/Properties.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/config/Properties.kt
@@ -37,4 +37,5 @@ class ObjectStoreProperties {
 @ConfigurationProperties(prefix = "service")
 class ServiceProperties {
     @NotNull lateinit var name: String
+    var objectFetchEnabled: Boolean = false
 }

--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/ObjectController.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/ObjectController.kt
@@ -6,14 +6,18 @@ import io.p8e.util.orThrowNotFound
 import io.p8e.util.toJavaPublicKey
 import io.provenance.p8e.shared.domain.AffiliateRecord
 import io.provenance.p8e.shared.service.AffiliateService
+import io.provenance.p8e.webservice.config.ErrorMessage
+import io.provenance.p8e.webservice.config.ServiceProperties
 import org.jetbrains.exposed.sql.transactions.transaction
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.util.*
 
 @CrossOrigin(origins = ["http://localhost:3000"], allowCredentials = "true")
 @RestController
 @RequestMapping("object")
-open class ObjectController(private val affiliateService: AffiliateService) {
+open class ObjectController(private val affiliateService: AffiliateService, private val serviceProperties: ServiceProperties) {
     @GetMapping()
     fun getJson(
         @RequestParam("hash") hash: String,
@@ -21,6 +25,10 @@ open class ObjectController(private val affiliateService: AffiliateService) {
         @RequestParam("contractSpecHash") contractSpecHash: String,
         @RequestParam("publicKey") publicKey: String
     ): Any {
+        if (!serviceProperties.objectFetchEnabled) {
+            return ResponseEntity(ErrorMessage(listOf("Object fetching disabled")), HttpStatus.FORBIDDEN)
+        }
+
         val affiliate = transaction { affiliateService.get(publicKey.toJavaPublicKey()) }
 
         requireNotNull(affiliate) { "Affiliate not found with public key $publicKey" }

--- a/p8e-api-webservice/src/main/resources/application-container.properties
+++ b/p8e-api-webservice/src/main/resources/application-container.properties
@@ -45,3 +45,6 @@ provenance.keystone.url=${PROVENANCE_KEYSTONE_URL}
 # Smart Key
 smartkey.apikey=${SMARTKEY_API_KEY}
 smartkey.group-id=${SMARTKEY_GROUP_ID}
+
+# Object Fetching
+service.object-fetch-enabled=${SERVICE_OBJECT_FETCH_ENABLED:false}

--- a/p8e-api-webservice/src/main/resources/application-development.properties
+++ b/p8e-api-webservice/src/main/resources/application-development.properties
@@ -33,3 +33,6 @@ objectstore.key=
 # Smart Key
 smartkey.apikey=${SMARTKEY_API_KEY}
 smartkey.group-id=${SMARTKEY_GROUP_ID}
+
+# Object Fetching
+service.object-fetch-enabled=true

--- a/p8e-api-webservice/src/main/resources/application-local.properties
+++ b/p8e-api-webservice/src/main/resources/application-local.properties
@@ -44,3 +44,6 @@ provenance.keystone.url=https://test.provenance.io/keystone/key/registration/sec
 # Smart Key
 smartkey.apikey=${SMARTKEY_API_KEY}
 smartkey.group-id=${SMARTKEY_GROUP_ID}
+
+# Object Fetching
+service.object-fetch-enabled=true

--- a/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/domain/Scope.kt
+++ b/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/domain/Scope.kt
@@ -51,7 +51,7 @@ open class ScopeEntityClass : UUIDEntityClass<ScopeRecord>(
             if (q != null) {
                 try {
                     val uuid = UUID.fromString(q.trim())
-                    expressions.add((ScopeTable.id eq uuid) or (ScopeTable.scopeUuid eq uuid))
+                    expressions.add(ScopeTable.scopeUuid eq uuid)
                 } catch (e: IllegalArgumentException) {
                     // invalid uuid
                 }


### PR DESCRIPTION
* The current envelope search mechanism usually times out in test, due to the inefficient query that was attempting to search all uuid columns. I changed this search (in the UI as well) to have a specific uuid searched for so the uuid indexes can be utilized. The other solution would be to have a composite index I think, but I tried creating one of these in test to see if it would help the explain, and it was taking forever, so I decided to just go this route instead. This is to help Peter find the state of things in test when he needs to
* Matt requested that we find a way to lock down access to the PII in the UI in prod some more, so I added a flag to just disable that endpoint altogether. Since we are not sure what the UI's role will be with the new client sdk anyways, this is the quick solution given that the prod ui doesn't get much use at all.