### PR TITLE
Fix for connection reset

### DIFF
--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/config/AppConfig.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/config/AppConfig.kt
@@ -8,9 +8,9 @@ import com.fortanix.sdkms.v1.api.SecurityObjectsApi
 import com.fortanix.sdkms.v1.api.SignAndVerifyApi
 import com.fortanix.sdkms.v1.auth.ApiKeyAuth
 import io.p8e.crypto.SignerFactory
-import io.p8e.crypto.SmartKeySigner
 import io.p8e.util.configureProvenance
 import io.provenance.os.client.OsClient
+import io.provenance.p8e.encryption.util.ExternalKeyCustodyApi
 import io.provenance.p8e.shared.config.JwtProperties
 import io.provenance.p8e.shared.config.ProvenanceKeystoneProperties
 import io.provenance.p8e.shared.config.SmartKeyProperties
@@ -51,10 +51,11 @@ class AppConfig : WebMvcConfigurer {
     }
 
     @Bean
-    fun osClient(objectMapper: ObjectMapper, objectStoreProperties: ObjectStoreProperties): OsClient =
+    fun osClient(objectMapper: ObjectMapper, objectStoreProperties: ObjectStoreProperties, externalKeyCustodyApi: ExternalKeyCustodyApi): OsClient =
         OsClient(
             uri = URI(objectStoreProperties.url),
-            deadlineMs = 60000
+            deadlineMs = 60000,
+            extEncryptSigningApi = externalKeyCustodyApi
         )
 
     @Bean
@@ -123,4 +124,7 @@ class AppConfig : WebMvcConfigurer {
 
     @Bean
     fun signer(signAndVerifyApi: SignAndVerifyApi): SignerFactory = SignerFactory(signAndVerifyApi)
+
+    @Bean
+    fun externalEncryptSignApi(securityObjectsApi: SecurityObjectsApi) = ExternalKeyCustodyApi(securityObjectsApi)
 }

--- a/p8e-api/src/main/kotlin/io/provenance/engine/config/AppConfig.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/config/AppConfig.kt
@@ -16,7 +16,7 @@ import feign.Feign
 import feign.jackson.JacksonDecoder
 import feign.jackson.JacksonEncoder
 import io.p8e.crypto.SignerFactory
-import io.p8e.crypto.SmartKeySigner
+import io.provenance.p8e.encryption.util.ExternalKeyCustodyApi
 import io.p8e.util.configureProvenance
 import io.provenance.engine.crypto.Account
 import io.provenance.engine.domain.RPCClient
@@ -134,10 +134,11 @@ class AppConfig : WebMvcConfigurer {
     }
 
     @Bean
-    fun osClient(objectMapper: ObjectMapper, objectStoreProperties: ObjectStoreProperties): OsClient =
+    fun osClient(objectMapper: ObjectMapper, objectStoreProperties: ObjectStoreProperties, externalKeyCustodyApi: ExternalKeyCustodyApi): OsClient =
         OsClient(
             uri = URI(objectStoreProperties.url),
-            deadlineMs = 60000
+            deadlineMs = 60000,
+            extEncryptSigningApi = externalKeyCustodyApi
         )
 
     @Bean
@@ -255,4 +256,7 @@ class AppConfig : WebMvcConfigurer {
 
     @Bean
     fun signer(signAndVerifyApi: SignAndVerifyApi): SignerFactory = SignerFactory(signAndVerifyApi)
+
+    @Bean
+    fun externalEncryptSignApi(securityObjectsApi: SecurityObjectsApi) = ExternalKeyCustodyApi(securityObjectsApi)
 }

--- a/p8e-encryption/src/main/kotlin/io/provenance/p8e/encryption/experimental/extensions/CryptoExtensions.kt
+++ b/p8e-encryption/src/main/kotlin/io/provenance/p8e/encryption/experimental/extensions/CryptoExtensions.kt
@@ -83,25 +83,25 @@ fun EncryptionProtos.Audience.toCryptogram(): ProvenanceECIESCryptogram {
 
 fun String.toSecretKeySpecProv() = ProvenanceAESCrypt.secretKeySpecGenerate(Base64.getDecoder().decode(this))
 
-fun String.toAgreeKey(transientKey: String): KeyObject {
-       val keyUuid = this
-       val request = AgreeKeyRequest().apply {
-            privateKey = SobjectDescriptor().kid(keyUuid)
-            publicKey = SobjectDescriptor().transientKey(transientKey)
-            name = keyUuid
-            keySize = ECUtils.AGREEKEY_SIZE
-            keyType = ObjectType.OPAQUE
-            mechanism = AgreeKeyMechanism.HELLMAN
-            transient = true
-        }
-        return SecurityObjectsApi().agreeKey(request)
+fun String.toAgreeKey(transientKey: String, securityObjectsApi: SecurityObjectsApi): KeyObject {
+    val keyUuid = this
+    val request = AgreeKeyRequest().apply {
+        privateKey = SobjectDescriptor().kid(keyUuid)
+        publicKey = SobjectDescriptor().transientKey(transientKey)
+        name = keyUuid
+        keySize = ECUtils.AGREEKEY_SIZE
+        keyType = ObjectType.OPAQUE
+        mechanism = AgreeKeyMechanism.HELLMAN
+        transient = true
+    }
+    return securityObjectsApi.agreeKey(request)
 }
 
 /**
  * A transient security object will be created, meaning this security object is for one time use
  * and will not be stored into SmartKey's repository.
  */
-fun PublicKey.toTransientSecurityObject(): KeyObject {
+fun PublicKey.toTransientSecurityObject(securityObjectsApi: SecurityObjectsApi): KeyObject {
     val ephemeralPublicKey = this
     val request = SobjectRequest().apply {
         value = ephemeralPublicKey.encoded
@@ -109,5 +109,5 @@ fun PublicKey.toTransientSecurityObject(): KeyObject {
         objType = ObjectType.EC
         transient = true
     }
-    return SecurityObjectsApi().importSecurityObject(request)
+    return securityObjectsApi.importSecurityObject(request)
 }

--- a/p8e-encryption/src/main/kotlin/io/provenance/p8e/encryption/util/ExternalKeyCustodyApi.kt
+++ b/p8e-encryption/src/main/kotlin/io/provenance/p8e/encryption/util/ExternalKeyCustodyApi.kt
@@ -1,0 +1,24 @@
+package io.provenance.p8e.encryption.util
+
+import com.fortanix.sdkms.v1.api.SecurityObjectsApi
+
+/**
+ * A wrapper class for all external key custody apis that are needed.
+ *
+ */
+class ExternalKeyCustodyApi(
+    private val securityObjectsApi: SecurityObjectsApi
+) {
+    /**
+     * Hold a reference of the external key custody apis for usage without resetting the connection of
+     * of previous API connection that was setup during AppConfig time.
+     *
+     * ~~Add any new needed key custody APIs below.~~
+     *
+     */
+
+    fun getSmartKeySecurityObj(): SecurityObjectsApi {
+        return securityObjectsApi
+    }
+
+}


### PR DESCRIPTION
Datadog logs were showing some connection reset errors when extension functions were called to convert ephemeral keys to agree keys and transient keys via the SmartKey security object api. The connection reset may have been caused because a new instance of the SecurityObjectApi object was created during this transformation. 

The fix was to add an ExternalKeyCustody class that holds a reference of the security object api that was created during AppConfig time (so that no connection is interrupted).