### PR TITLE
Close down contract manager after fetching object

### DIFF
--- a/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/ObjectController.kt
+++ b/p8e-api-webservice/src/main/kotlin/io/provenance/p8e/webservice/controller/ObjectController.kt
@@ -34,7 +34,7 @@ open class ObjectController(private val affiliateService: AffiliateService, priv
         requireNotNull(affiliate) { "Affiliate not found with public key $publicKey" }
 
         // todo: figure out how to properly authenticate to fetch object json now
-        return ContractManager.create(affiliate.privateKey!!).let { cm ->
+        return ContractManager.create(affiliate.privateKey!!).use { cm ->
             cm.client.loadProtoJson(hash, className, contractSpecHash)
         }
     }


### PR DESCRIPTION
- I believe this was causing the webservice to have one contract manager running per time the object fetch endpoint was called :facepalm:
- Side note: object fetch definitely doesn't work for SmartKey affiliates, since we have no way of grabbing the private key... but I knew that already and with the new client sdk, I don't think it matters