### PR TITLE
only complete event in async ACK if event type is what is expected

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/EnvelopeService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/EnvelopeService.kt
@@ -268,7 +268,7 @@ class EnvelopeService(
             return record
         }
 
-        eventService.completeInProgressEvent(record.uuid.value)
+        eventService.completeInProgressEvent(record.uuid.value, Event.ENVELOPE_REQUEST)
 
         return envelopeStateEngine.onHandleRead(record)
     }
@@ -300,7 +300,7 @@ class EnvelopeService(
                     }
             }
             .build()
-        eventService.completeInProgressEvent(record.uuid.value)
+        eventService.completeInProgressEvent(record.uuid.value, Event.ENVELOPE_ERROR)
 
         return record
     }
@@ -321,7 +321,7 @@ class EnvelopeService(
         envelopeStateEngine.onHandleComplete(record)
         metricsService.logEnvelopeStats(record)
 
-        eventService.completeInProgressEvent(record.uuid.value)
+        eventService.completeInProgressEvent(record.uuid.value, Event.ENVELOPE_RESPONSE)
 
         return record
     }

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/EventService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/EventService.kt
@@ -51,9 +51,11 @@ class EventService() {
     fun submitEvent(event: P8eEvent, envelopeUuid: UUID, status: EventStatus = EventStatus.CREATED, created: OffsetDateTime = OffsetDateTime.now()): EventRecord =
         EventRecord.insertOrUpdate(event, envelopeUuid, status, created, created).also(::submitToChannel)
 
-    fun completeInProgressEvent(envelopeUuid: UUID) = EventRecord.findByEnvelopeUuidForUpdate(envelopeUuid)?.let {
-        it.status = EventStatus.COMPLETE
-    }
+    fun completeInProgressEvent(envelopeUuid: UUID, expectedEventType: Event) = EventRecord.findByEnvelopeUuidForUpdate(envelopeUuid)
+        ?.takeIf { it.event == expectedEventType }
+        ?.let {
+            it.status = EventStatus.COMPLETE
+        }
 
     private fun submitToChannel(record: EventRecord) {
         if (!SKIPPABLE_EVENTS.contains(record.event)) {

--- a/p8e-api/src/test/kotlin/service/EventServiceTest.kt
+++ b/p8e-api/src/test/kotlin/service/EventServiceTest.kt
@@ -112,7 +112,7 @@ class EventServiceTest {
     fun `Test in-progress events are updated to completed`() {
         transaction {
             //Execute
-            eventService.completeInProgressEvent(envelopeRecord.uuid.value)
+            eventService.completeInProgressEvent(envelopeRecord.uuid.value, Event.ENVELOPE_REQUEST)
 
             //Validate
             val lastUpdatedRow = EventTable.selectAll().last()


### PR DESCRIPTION
- not doing so could let a stray ack get stuff stuck (in index mostly it seems)
- Seems like if indexing failed initially (likely due to momentary ES difficulty), so the initial in-memory event via the channel didn't get processed, and an ack for that envelope happened in-between the initial failure and a retry, the event would get stuck as INDEX/COMPLETE, when in reality it should have been retried