### PR TITLE
set block height timeout on transactions

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/config/Properties.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/config/Properties.kt
@@ -56,6 +56,7 @@ class ChaincodeProperties {
     @NotNull var txBatchSize: Int = 25
     @NotNull var gasMultiplier: Double = 1.0
     @NotNull var maxGasMultiplierPerDay: Int = 1000
+    @NotNull var blockHeightTimeoutInterval: Int = 12
 }
 
 @ConfigurationProperties(prefix = "elasticsearch")

--- a/p8e-api/src/main/kotlin/io/provenance/engine/config/Properties.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/config/Properties.kt
@@ -56,7 +56,7 @@ class ChaincodeProperties {
     @NotNull var txBatchSize: Int = 25
     @NotNull var gasMultiplier: Double = 1.0
     @NotNull var maxGasMultiplierPerDay: Int = 1000
-    @NotNull var blockHeightTimeoutInterval: Int = 12
+    @NotNull var blockHeightTimeoutInterval: Int = 20
 }
 
 @ConfigurationProperties(prefix = "elasticsearch")

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
@@ -206,6 +206,7 @@ class ChaincodeInvokeService(
             log.debug("Internal structures\nblockScopeIds: $blockScopeIds\npriorityFutureScopeToQueue: ${priorityScopeBacklog.entries.map { e -> "${e.key} => ${e.value.size}"}}")
 
             try {
+                log.info("currentBlockHeight = $currentBlockHeight | timeout = ${currentBlockHeight + chaincodeProperties.blockHeightTimeoutInterval}")
                 val txBody = batch.map {
                     it.attempts++
                     it.request

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
@@ -209,7 +209,9 @@ class ChaincodeInvokeService(
                 val txBody = batch.map {
                     it.attempts++
                     it.request
-                }.toTxBody()
+                }.toTxBody().toBuilder()
+                    .setTimeoutHeight(currentBlockHeight + chaincodeProperties.blockHeightTimeoutInterval)
+                .build()
 
                 // Send the transactions to the blockchain.
                 val resp = synchronized(provenanceGrpc) { batchTx(txBody) }

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/TransactionStatusService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/TransactionStatusService.kt
@@ -35,6 +35,7 @@ class TransactionStatusService(
         }.forUpdate().let { envelopes ->
             val sameInstanceKeys = envelopes.map { it.publicKey.toJavaPublicKey() }.toTypedArray()
             envelopes.forEach { envelope ->
+                ChaincodeInvokeService.unlockScope(envelope.scope.scopeUuid.toString())
                 envelopeStateEngine.onHandleError(envelope)
                 envelope.addChaincodeError(error).also {
                     val envWithError = Envelope.EnvelopeUuidWithError.newBuilder()
@@ -65,7 +66,7 @@ class TransactionStatusService(
             envelope.status = Status.SIGNED
             envelope.chaincodeTime = null
 
-            if (envelope.isInvoker ?: false) {
+            if (envelope.isInvoker == true) {
                 val event = envelope.uuid.value.toProtoUuidProv().toEvent(Event.ENVELOPE_CHAINCODE)
                 ChaincodeInvokeService.unlockScope(envelope.scope.scopeUuid.toString())
                 eventService.submitEvent(event, envelope.uuid.value)

--- a/p8e-api/src/main/resources/application-container.properties
+++ b/p8e-api/src/main/resources/application-container.properties
@@ -46,6 +46,7 @@ chaincode.emptyIterationBackoffMS=${CHAINCODE_EMPTY_ITERATION_BACKOFF:750}
 chaincode.txBatchSize=${CHAINCODE_TX_BATCH_SIZE:25}
 chaincode.gasMultiplier=${CHAINCODE_GAS_MULTIPLIER:1.0}
 chaincode.maxGasMultiplierPerDay=${CHAINCODE_MAX_GAS_MULTIPLIER_PER_DAY:1000}
+chaincode.blockHeightTimeoutInterval=${CHAINCODE_BLOCK_HEIGHT_TIMEOUT_INTERVAL:12}
 
 # Elasticsearch
 elasticsearch.host=${ELASTICSEARCH_HOST}

--- a/p8e-api/src/main/resources/application-container.properties
+++ b/p8e-api/src/main/resources/application-container.properties
@@ -46,7 +46,7 @@ chaincode.emptyIterationBackoffMS=${CHAINCODE_EMPTY_ITERATION_BACKOFF:750}
 chaincode.txBatchSize=${CHAINCODE_TX_BATCH_SIZE:25}
 chaincode.gasMultiplier=${CHAINCODE_GAS_MULTIPLIER:1.0}
 chaincode.maxGasMultiplierPerDay=${CHAINCODE_MAX_GAS_MULTIPLIER_PER_DAY:1000}
-chaincode.blockHeightTimeoutInterval=${CHAINCODE_BLOCK_HEIGHT_TIMEOUT_INTERVAL:12}
+chaincode.blockHeightTimeoutInterval=${CHAINCODE_BLOCK_HEIGHT_TIMEOUT_INTERVAL:20}
 
 # Elasticsearch
 elasticsearch.host=${ELASTICSEARCH_HOST}


### PR DESCRIPTION
- to prevent transactions from getting stuck in the mempool of a node for whatever reason (usually gas related)
- tested with a positive timeout height of 12 and transactions completed normally, tested with a negative height and transactions were immediately rejected, not sure how to induce a stuck transaction locally