### PR TITLE
look up affiliate index name by any public key

### DIFF
--- a/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/service/AffiliateService.kt
+++ b/p8e-shared/src/main/kotlin/io/provenance/p8e/shared/service/AffiliateService.kt
@@ -212,7 +212,7 @@ class AffiliateService(
      * @return the index name for the specified public key
      */
     @Cacheable(AFFILIATE_INDEX_NAME)
-    fun getIndexNameByPublicKey(publicKey: PublicKey) = AffiliateRecord.findByPublicKey(publicKey)?.indexName ?: DEFAULT_INDEX_NAME
+    fun getIndexNameByPublicKey(publicKey: PublicKey) = get(publicKey)?.indexName ?: DEFAULT_INDEX_NAME
 
     /**
      * Save or update an affiliate.


### PR DESCRIPTION
- was only using the public_key before, which was causing the default index to be used for any affiliate with a different auth_public_key from their public_key