### PR TITLE
add in not equals string query option

### DIFF
--- a/p8e-index-client/src/main/kotlin/io/p8e/index/client/query/StringQuery.kt
+++ b/p8e-index-client/src/main/kotlin/io/p8e/index/client/query/StringQuery.kt
@@ -3,6 +3,7 @@ package io.p8e.index.client.query
 import io.p8e.index.client.query.OperationType.STRING
 import io.p8e.index.client.query.StringOperationType.EQUAL
 import io.p8e.index.client.query.StringOperationType.LIKE
+import io.p8e.index.client.query.StringOperationType.NOT_EQUAL
 import io.p8e.index.client.query.StringOperationType.REGEXP
 import java.util.UUID
 
@@ -11,6 +12,14 @@ infix fun String.equal(uuid: UUID) = this.equal(uuid.toString())
 infix fun String.equal(value: String): Operation {
     return StringOperation(
         EQUAL,
+        this,
+        value
+    )
+}
+
+infix fun String.notEqual(value: String): Operation {
+    return StringOperation(
+        NOT_EQUAL,
         this,
         value
     )
@@ -42,6 +51,7 @@ class StringOperation(
 
 enum class StringOperationType {
     EQUAL,
+    NOT_EQUAL,
     LIKE,
-    REGEXP
+    REGEXP,
 }


### PR DESCRIPTION
@jazzy-figure was needing a way to add in a not equals clause to a query and it turns out we don't support that. You can do it through the 'elasticsearch' versions of the query endpoints, but those don't support the pagination that the regular query endpoints do