### PR TITLE
Query chain directly when fetching latest scope for IndexGrpc

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/grpc/v1/IndexGrpc.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/grpc/v1/IndexGrpc.kt
@@ -159,13 +159,13 @@ class IndexGrpc(
                 .map { it.toUuidProv() }
                 .filterNot { fetchedUuids.contains(it) }
                 .also { log.debug("Attempting to fetch an additional ${it.count()} scopes from chain") }
-                .map {
+                .mapNotNull {
                     try {
                         provenanceGrpcService.retrieveScope(it)
                     } catch (e: Exception) {
                         null
                     }
-                }.filterNotNull()
+                }
                 .contractScopesToScopeWrappers()
 
             log.debug("Fetched additional ${chainScopes.scopesCount} scopes from chain")

--- a/p8e-api/src/main/kotlin/io/provenance/engine/grpc/v1/IndexGrpc.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/grpc/v1/IndexGrpc.kt
@@ -36,7 +36,6 @@ import io.provenance.os.client.OsClient
 import io.provenance.p8e.shared.extension.logger
 import io.provenance.p8e.shared.util.P8eMDC
 import io.p8e.proto.Util.UUID
-import io.p8e.util.toMessageWithStackTrace
 import io.provenance.engine.service.ProvenanceGrpcService
 import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.index.query.QueryBuilders

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ProvenanceGrpcService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ProvenanceGrpcService.kt
@@ -158,6 +158,8 @@ class ProvenanceGrpcService(
             )
         }
 
+    fun retrieveScope(uuid: UUID): ContractScope.Scope = retrieveScope(uuid.toString())
+
     fun retrieveScope(address: String): ContractScope.Scope {
         val (scopeResponse, contractSpecHashLookup, scopeSpecificationName) = try {
             val scopeResponse = metadataQueryService.scope(


### PR DESCRIPTION
- Allows scopes that were created by new scope sdk to be queried properly via the old p8e
- This is an important piece of the los transition to the new sdk (since the final AssignToServicer contract requires scope sdk multiparty support to move that to the new sdk)
- Also prevent error resulting from incoming events that have no `lastEvent.executionUuid` set (i.e. scopes written by something other than the legacy p8e system, such as the new scope sdk, p8e doesn't need to do anything with these scopes anyways)
- Note: I went this route for fixing the query issue, rather than allowing incoming events w/o a last execution uuid from being inserted into the index_scope table and leaving the query alone, as the new scope sdk will write piecemeal record updates for existing scopes, so a ScopeUpdated event won't necessarily be emitted, and therefore subsequent updates to the scope wouldn't be recorded in the p8e index_scope cache, so it seems better to just use the chain as the source of truth...
- Note: This won't return the block number/block transaction index for these types of scopes since that information doesn't exist on the scope response from chain