### PR TITLE
move mailboxService.error call into transaction

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/batch/MailboxReaper.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/batch/MailboxReaper.kt
@@ -199,16 +199,16 @@ class MailboxReaper(
             log.info("Processing mail error from key:{} poll:{}, message:{}", MailboxMeta.ERROR_RESPONSE, uuid, error.message)
 
             return transaction {
-                envelopeService.error(item.publicKey, error)
-            }?.also {
-                // Send errors to parties on recital list if invoker sans the sender of the original message
-                if (it.data.isInvoker)
-                    mailboxService.error(
-                        item.publicKey,
-                        it.data.input,
-                        error,
-                        ownerAudience.publicKey.toPublicKey()
-                    )
+                envelopeService.error(item.publicKey, error)?.also {
+                    if (it.data.isInvoker) {
+                        mailboxService.error(
+                            item.publicKey,
+                            it.data.input,
+                            error,
+                            ownerAudience.publicKey.toPublicKey()
+                        )
+                    }
+                }
             }?.data
                 ?.result
                 ?: defaultProto


### PR DESCRIPTION
- mailboxService.error calls into affiliateService to get signer, etc. which does some db queries, so this call needs to also be in the transaction, otherwise it throws a 'No transaction in context' error
- there is an object store put call in here, but it should be relatively fast, so I don't _think_ it is an issue to just put the whole call in the transaction, vs. putting a transaction inside of the MailboxService.error function