### PR TITLE
Allow for shorter Sha512 object hashes to account for records written by the new sdk

### DIFF
--- a/os-client/src/main/kotlin/io/provenance/os/client/OsClient.kt
+++ b/os-client/src/main/kotlin/io/provenance/os/client/OsClient.kt
@@ -88,8 +88,8 @@ open class OsClient(
     }
 
     fun get(sha512: ByteArray, publicKey: PublicKey, deadlineSeconds: Long = 60L): DIMEInputStream {
-        if (sha512.size != 64) {
-            throw IllegalArgumentException("Provided SHA-512 must be byte array of size 64, found size: ${sha512.size}")
+        if (sha512.size < 16) {
+            throw IllegalArgumentException("Provided hash must be byte array of at least size 16, found size: ${sha512.size}")
         }
 
         val finishLatch = CountDownLatch(1)


### PR DESCRIPTION
- The new sdk uses shorter hashes for things in object store, this allows the old p8e-api sdk to hydrate records written to a scope by the new sdk
- This is the same check that the new sdk's OsClient get method uses