### PR TITLE
just use the jar hash for the classloader cache key

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/index/ProtoIndexer.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/index/ProtoIndexer.kt
@@ -49,7 +49,7 @@ class ProtoIndexer(
                         // Try to re-use MemoryClassLoader if possible for caching reasons
                         val spec = _definitionService.loadProto(encryptionKeyRef, group.specification, ContractSpec::class.java.name) as ContractSpec
 
-                        val classLoaderKey = "${spec.definition.resourceLocation.ref.hash}-${spec.considerationSpecsList.first().outputSpec.spec.resourceLocation.ref.hash}"
+                        val classLoaderKey = spec.definition.resourceLocation.ref.hash // one classloader per contract jar
                         val memoryClassLoader = ClassLoaderCache.classLoaderCache.computeIfAbsent(classLoaderKey) {
                             MemoryClassLoader("", ByteArrayInputStream(ByteArray(0)))
                         }


### PR DESCRIPTION
- no need to include the first consideration hash, as one class loader per jar is appropriate
- scopes with records written by the new sdk would end up with record groups referencing spec objects in object store that didn't have any 'considerationSpecsList', since the spec proto stored in OS has changed slightly and that is a reserved field now that will always be empty, this was leading to a NoSuchElementException when constructing the classLoaderKey using the `first()` call