### PR TITLE
Fix chaincode retry state transition

### DIFF
--- a/p8e-api/src/test/kotlin/service/EventServiceTest.kt
+++ b/p8e-api/src/test/kotlin/service/EventServiceTest.kt
@@ -219,4 +219,24 @@ class EventServiceTest {
         Assert.assertEquals(Event.ENVELOPE_RESPONSE, updatedRecord.event)
         Assert.assertEquals("some-other-test-message".toByteString(), updatedRecord.payload.message)
     }
+
+    @Test
+    fun `Verify ENVELOPE_CHAINCODE to ENVELOPE_CHAINCODE is a valid transition`() {
+        // CHAINCODE -> CHAINCODE transition for TransactionStatusService.retryDead case
+        val event = Events.P8eEvent.newBuilder()
+            .setEvent(Event.ENVELOPE_CHAINCODE)
+            .setMessage("some-test-message".toByteString())
+            .build()
+
+        transaction { EventRecord.insert(event, envelopeRecord.uuid.value) }
+
+        val event2 = Events.P8eEvent.newBuilder()
+            .setEvent(Event.ENVELOPE_CHAINCODE)
+            .setMessage("some-other-test-message".toByteString())
+            .build()
+        val updatedRecord = transaction { eventService.submitEvent(event2, envelopeRecord.uuid.value, EventStatus.CREATED, createdTime) }
+
+        // event should be updated, since you can go from ENVELOPE_CHAINCODE -> ENVELOPE_CHAINCODE
+        Assert.assertEquals("some-other-test-message".toByteString(), updatedRecord.payload.message)
+    }
 }


### PR DESCRIPTION
- the retrial of 'dead' transactions (expired transactions that come back from the chain query as not found) was getting filtered out by the EventService, due to the 'transition' between ENVELOPE_CHAINCODE -> ENVELOPE_CHAINCODE not being listed as allowed
- Also added in an MDC fix for the event handler threads