### PR TITLE
look up signing key via AffiliateService when erroring envelope

### DIFF
--- a/p8e-api/src/test/kotlin/helper/TestUtils.kt
+++ b/p8e-api/src/test/kotlin/helper/TestUtils.kt
@@ -201,9 +201,10 @@ class TestUtils {
                 )
                 .build()
 
-        fun generateTestEnvelope(keys: KeyPair, scopeData: ScopeRecord, scopeWithLastEvent: Boolean = true, executionUUID: UUID? = null, contract: Contracts.Contract? = null): ContractScope.Envelope {
+        fun generateTestEnvelope(keys: KeyPair, scopeData: ScopeRecord, scopeWithLastEvent: Boolean = true, executionUUID: UUID? = null, contract: Contracts.Contract? = null, encryptionKeyPair: KeyPair? = null): ContractScope.Envelope {
             val executionUuid = executionUUID?.toProtoUuidProv() ?: UUID.randomUUID().toProtoUuidProv()
             val contract = contract ?: generateTestContract(keys, scopeData)
+            val encKeyPair = encryptionKeyPair ?: keys
 
             val lastEvent = if(scopeWithLastEvent) {
                 ContractScope.Event.newBuilder()
@@ -232,7 +233,7 @@ class TestUtils {
                             .setSignature(UUID.randomUUID().toString())
                             .setSigner(
                                 PK.SigningAndEncryptionPublicKeys.newBuilder()
-                                    .setEncryptionPublicKey(keys.public.toPublicKeyProto())
+                                    .setEncryptionPublicKey(encKeyPair.public.toPublicKeyProto())
                                     .setSigningPublicKey(keys.public.toPublicKeyProto())
                                     .build() // Build Signer
                             )
@@ -249,7 +250,7 @@ class TestUtils {
                                     .setSignerRole(ContractSpecs.PartyType.OWNER)
                                     .setSigner(
                                         PK.SigningAndEncryptionPublicKeys.newBuilder()
-                                            .setEncryptionPublicKey(keys.public.toPublicKeyProto())
+                                            .setEncryptionPublicKey(encKeyPair.public.toPublicKeyProto())
                                             .setSigningPublicKey(keys.public.toPublicKeyProto())
                                             .build() // Build Signer
                                     )
@@ -264,7 +265,7 @@ class TestUtils {
                                     .setGroupUuid(groupUuid)
                                     .setExecutor(
                                         PK.SigningAndEncryptionPublicKeys.newBuilder()
-                                            .setEncryptionPublicKey(keys.public.toPublicKeyProto())
+                                            .setEncryptionPublicKey(encKeyPair.public.toPublicKeyProto())
                                             .setSigningPublicKey(keys.public.toPublicKeyProto())
                                             .build() // Build Executor
                                     )
@@ -274,7 +275,7 @@ class TestUtils {
                                                 .setSignerRole(ContractSpecs.PartyType.OWNER)
                                                 .setSigner(
                                                     PK.SigningAndEncryptionPublicKeys.newBuilder()
-                                                        .setEncryptionPublicKey(keys.public.toPublicKeyProto())
+                                                        .setEncryptionPublicKey(encKeyPair.public.toPublicKeyProto())
                                                         .setSigningPublicKey(keys.public.toPublicKeyProto())
                                                         .build() // Build Signer
                                                 )

--- a/p8e-api/src/test/kotlin/helper/TestUtils.kt
+++ b/p8e-api/src/test/kotlin/helper/TestUtils.kt
@@ -57,8 +57,9 @@ class TestUtils {
                 it.sign()
             }
 
-        fun generateTestContract(keys: KeyPair, scopeData: ScopeRecord): Contracts.Contract =
-            Contracts.Contract.newBuilder()
+        fun generateTestContract(keys: KeyPair, scopeData: ScopeRecord, encryptionKeys: KeyPair? = null): Contracts.Contract {
+            val encryptionKeyPair = encryptionKeys ?: keys
+            return Contracts.Contract.newBuilder()
                 .setDefinition(
                     Common.DefinitionSpec.newBuilder()
                         .setName("def-contract-name")
@@ -81,7 +82,7 @@ class TestUtils {
                                 .setSignature(UUID.randomUUID().toString())
                                 .setSigner(
                                     PK.SigningAndEncryptionPublicKeys.newBuilder()
-                                        .setEncryptionPublicKey(keys.public.toPublicKeyProto())
+                                        .setEncryptionPublicKey(encryptionKeyPair.public.toPublicKeyProto())
                                         .setSigningPublicKey(keys.public.toPublicKeyProto())
                                         .build()
                                 )
@@ -109,7 +110,7 @@ class TestUtils {
                 )
                 .setInvoker(
                     PK.SigningAndEncryptionPublicKeys.newBuilder()
-                        .setEncryptionPublicKey(keys.public.toPublicKeyProto())
+                        .setEncryptionPublicKey(encryptionKeyPair.public.toPublicKeyProto())
                         .setSigningPublicKey(keys.public.toPublicKeyProto())
                         .build()
                 )
@@ -191,7 +192,7 @@ class TestUtils {
                             .setSignerRole(ContractSpecs.PartyType.OWNER)
                             .setSigner(
                                 PK.SigningAndEncryptionPublicKeys.newBuilder()
-                                    .setEncryptionPublicKey(keys.public.toPublicKeyProto())
+                                    .setEncryptionPublicKey(encryptionKeyPair.public.toPublicKeyProto())
                                     .setSigningPublicKey(keys.public.toPublicKeyProto())
                                     .build()
                             )
@@ -200,6 +201,7 @@ class TestUtils {
                     )
                 )
                 .build()
+        }
 
         fun generateTestEnvelope(keys: KeyPair, scopeData: ScopeRecord, scopeWithLastEvent: Boolean = true, executionUUID: UUID? = null, contract: Contracts.Contract? = null, encryptionKeyPair: KeyPair? = null): ContractScope.Envelope {
             val executionUuid = executionUUID?.toProtoUuidProv() ?: UUID.randomUUID().toProtoUuidProv()


### PR DESCRIPTION
The ol' different signing/encryption keys strikes again!

Homepoint originator in prod has different signing/encryption/auth keys, and when the servicing affiliate rejected an envelope, the error failed to propagate back to the Homepoint originator, since the incoming mail public key is the encryption key, while the envelope table key is the signing key. This ensures the correct key is used when processing incoming mail

- ensures correct key is used for envelope lookup, preventing error from being dropped