### PR TITLE
CVE-2021-44228 precaution

### DIFF
--- a/p8e-api-webservice/build.gradle
+++ b/p8e-api-webservice/build.gradle
@@ -41,6 +41,12 @@ sourceSets {
 configurations.all {
     // This is brought in by the object store client... We don't want figure dependencies in the p8e-api.
     exclude group: 'com.figure', module: 'figure-util'
+
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group == 'org.apache.logging.log4j') {
+            details.useVersion '2.15.0'
+        }
+    }
 }
 
 dependencies {

--- a/p8e-api-webservice/build.gradle
+++ b/p8e-api-webservice/build.gradle
@@ -38,12 +38,19 @@ sourceSets {
     }
 }
 
+boolean isMoreRecent( String a, String b ) {
+    [a,b]*.tokenize('.')*.collect { it as int }.with { u, v ->
+        Integer result = [u,v].transpose().findResult{ x,y -> x <=> y ?: null } ?: u.size() <=> v.size()
+        return (result == 1)
+    }
+}
+
 configurations.all {
     // This is brought in by the object store client... We don't want figure dependencies in the p8e-api.
     exclude group: 'com.figure', module: 'figure-util'
 
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-        if (details.requested.group == 'org.apache.logging.log4j') {
+        if (details.requested.group == 'org.apache.logging.log4j' && !isMoreRecent(details.requested.version, '2.15.0')) {
             details.useVersion '2.15.0'
         }
     }

--- a/p8e-api/build.gradle
+++ b/p8e-api/build.gradle
@@ -51,12 +51,19 @@ sourceSets {
     }
 }
 
+boolean isMoreRecent( String a, String b ) {
+    [a,b]*.tokenize('.')*.collect { it as int }.with { u, v ->
+        Integer result = [u,v].transpose().findResult{ x,y -> x <=> y ?: null } ?: u.size() <=> v.size()
+        return (result == 1)
+    }
+}
+
 configurations.all {
     // This is brought in by the object store client... We don't want figure dependencies in the p8e-api.
     exclude group: 'com.figure', module: 'figure-util'
 
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-        if (details.requested.group == 'org.apache.logging.log4j') {
+        if (details.requested.group == 'org.apache.logging.log4j' && !isMoreRecent(details.requested.version, '2.15.0')) {
             details.useVersion '2.15.0'
         }
     }

--- a/p8e-api/build.gradle
+++ b/p8e-api/build.gradle
@@ -54,6 +54,12 @@ sourceSets {
 configurations.all {
     // This is brought in by the object store client... We don't want figure dependencies in the p8e-api.
     exclude group: 'com.figure', module: 'figure-util'
+
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group == 'org.apache.logging.log4j') {
+            details.useVersion '2.15.0'
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
- We should **not be affected** since:
     - We use the default Springboot logback config
     - We are on Java 11
     - log4j-core doesn't appear on our classpath
     - we use log4j-over-slf4j

But I am adding this just to be extra safe