### PR TITLE
handle sha256/short hashes for interop w/ p8e-scope-sdk

### DIFF
--- a/os-client/src/main/kotlin/io/provenance/os/domain/inputstream/DIMEInputStream.kt
+++ b/os-client/src/main/kotlin/io/provenance/os/domain/inputstream/DIMEInputStream.kt
@@ -35,7 +35,8 @@ class DIMEInputStream(
     val signatures: List<Signature> = listOf(),
     val internalHash: Boolean = true,
     val externalHash: Boolean = true,
-    val extKeyCustodyApi: ExternalKeyCustodyApi
+    val extKeyCustodyApi: ExternalKeyCustodyApi,
+    val sha256Internal: Boolean = false
 ) : FilterInputStream(BufferedInputStream(`in`)) {
 
     private val internalInputStream = `in`
@@ -90,7 +91,7 @@ class DIMEInputStream(
             System.arraycopy(dimeBytes, 0, this, 4 + 2 + 4 + uuidBytes.size + 4 + metadataBytes.size + 4 + uriBytes.size + 4 + signaturesBytes.size + 4, dimeBytes.size)
         }
 
-    private val internalDigest = MessageDigest.getInstance("SHA-512")
+    private val internalDigest = MessageDigest.getInstance(if (sha256Internal) "SHA-256" else "SHA-512")
     private val externalDigest = MessageDigest.getInstance("SHA-512")
         .apply {
             update(header, 0, header.size)

--- a/os-client/src/main/kotlin/io/provenance/os/util/Util.kt
+++ b/os-client/src/main/kotlin/io/provenance/os/util/Util.kt
@@ -30,6 +30,16 @@ fun String.base64Encode() = String(Base64.getEncoder().encode(toByteArray()))
 
 fun String.base64Decode() = Base64.getDecoder().decode(this)
 
+/* SHA-256 Functionality for interoperability with p8e-scope-sdk */
+fun ByteArray.sha256() = Hashing.sha256().hashBytes(this).asBytes()
+fun ByteArray.loBytes() = slice(0 until 16)
+fun ByteArray.sha256LoBytes(): ByteArray {
+    return Hashing.sha256().hashBytes(this)
+        .asBytes()
+        .loBytes()
+        .toByteArray()
+}
+
 fun ByteArray.sha512() = Hashing.sha512().hashBytes(this).asBytes()!!
 
 fun ByteArray.crc32c() = Hashing.crc32c().hashBytes(this).asBytes()!!

--- a/p8e-api/src/main/kotlin/io/provenance/engine/grpc/v1/ObjectGrpc.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/grpc/v1/ObjectGrpc.kt
@@ -61,7 +61,7 @@ class ObjectGrpc(
         }.toSet()
 
         DefinitionService(osClient)
-            .save(encryptionPublicKey, msg, signer, audience)
+            .save(encryptionPublicKey, msg, signer, audience, sha256 = request.sha256, loHash = request.loHash)
             .toProto()
             .complete(responseObserver)
     }

--- a/p8e-common/src/main/kotlin/io/p8e/engine/extension/ProtoExtension.kt
+++ b/p8e-common/src/main/kotlin/io/p8e/engine/extension/ProtoExtension.kt
@@ -14,10 +14,12 @@ fun <T: Message> T.withAudience(audience: Set<ByteArray>): WithAudience {
         .build()
 }
 
-fun ByteArray.withAudience(audience: Set<ByteArray>): WithAudience {
+fun ByteArray.withAudience(audience: Set<ByteArray>, sha256: Boolean = false, loHash: Boolean = false): WithAudience {
     return WithAudience.newBuilder()
         .addAllAudience(audience.map { it.toByteString() })
         .setMessage(toByteString())
+        .setSha256(sha256)
+        .setLoHash(loHash)
         .build()
 }
 

--- a/p8e-encryption/src/main/kotlin/io/provenance/p8e/encryption/aes/ProvenanceAESCrypt.kt
+++ b/p8e-encryption/src/main/kotlin/io/provenance/p8e/encryption/aes/ProvenanceAESCrypt.kt
@@ -59,7 +59,7 @@ object ProvenanceAESCrypt {
      * Password based encryption using AES - GCM 256 bits.
      * additionalAuthenticatedData --AAD
      */
-    fun encrypt(inputStream: InputStream, additionalAuthenticatedData: String? = "", key: SecretKeySpec, useZeroIV: Boolean = false): InputStream {
+    fun encrypt(inputStream: InputStream, additionalAuthenticatedData: String? = "", key: SecretKeySpec, useZeroIV: Boolean = false, sha256: Boolean = false): InputStream {
         try {
             val iv = ByteArray(BLOCK_LENGTH)
             if (!useZeroIV) {
@@ -81,7 +81,7 @@ object ProvenanceAESCrypt {
             header.putInt(iv.size)
             header.put(iv)
 
-            return HashingCipherInputStream(inputStream, cipher, MessageDigest.getInstance("SHA-512"), header.array())
+            return HashingCipherInputStream(inputStream, cipher, MessageDigest.getInstance(if (sha256) "SHA-256" else "SHA-512"), header.array())
         } catch (t: Throwable) {
             throw CryptoException("Could not encrypt InputStream.", t)
         }

--- a/p8e-encryption/src/main/kotlin/io/provenance/p8e/encryption/dime/ProvenanceDIME.kt
+++ b/p8e-encryption/src/main/kotlin/io/provenance/p8e/encryption/dime/ProvenanceDIME.kt
@@ -320,7 +320,8 @@ object ProvenanceDIME {
                    additionalAudience: Map<EncryptionProtos.ContextType, Set<PublicKey>> = emptyMap(),
                    additionalAudienceAuthenticatedData: Map<EncryptionProtos.ContextType, Set<Pair<PublicKey, String>>> = emptyMap(),
                    processingAudienceKeys: List<PublicKey>,
-                   providedDEK: SecretKeySpec? = null
+                   providedDEK: SecretKeySpec? = null,
+                   sha256: Boolean = false,
     ): DIMEStreamProcessingModel {
 
         val messageDIME = EncryptionProtos.DIME.newBuilder()
@@ -330,9 +331,10 @@ object ProvenanceDIME {
         val processingScopedAudienceList = mutableListOf<Audience>()
 
         val encryptedPayload = ProvenanceAESCrypt.encrypt(
-                payload,
-                key = key,
-                useZeroIV = false
+            payload,
+            key = key,
+            useZeroIV = false,
+            sha256 = sha256
         )
 
         processingAudienceKeys.forEach { keyRef ->

--- a/p8e-proto-internal/src/main/proto/p8e/common.proto
+++ b/p8e-proto-internal/src/main/proto/p8e/common.proto
@@ -89,4 +89,6 @@ message ChaincodeTransaction {
 message WithAudience {
     repeated bytes audience = 1;
     bytes message = 2;
+    bool sha256 = 3; // default bool is 'false'
+    bool loHash = 4; // default bool is 'false'
 }

--- a/p8e-sdk/src/main/kotlin/io/p8e/client/EngineClient.kt
+++ b/p8e-sdk/src/main/kotlin/io/p8e/client/EngineClient.kt
@@ -68,7 +68,7 @@ interface P8eClient {
 
     fun <T : Message> saveProto(msg: T, executionUuid: UUID?, audience: Set<PublicKey> = setOf()): Location
 
-    fun storeObject(inputStream: InputStream, audience: Set<PublicKey>): Location
+    fun storeObject(inputStream: InputStream, audience: Set<PublicKey>, sha256: Boolean = false, loHash: Boolean = false): Location
 
     fun loadObject(hash: String): ByteArray
 
@@ -195,12 +195,18 @@ abstract class EventMonitorClient(
 
     override fun storeObject(
         inputStream: InputStream,
-        audience: Set<PublicKey>
+        audience: Set<PublicKey>,
+        sha256: Boolean,
+        loHash: Boolean,
     ): Location {
         return objectClient.store(
             inputStream.use {
                 it.readAllBytes()
-            }.withAudience(audience.map(ECUtils::convertPublicKeyToBytes).toSet())
+            }.withAudience(
+                audience.map(ECUtils::convertPublicKeyToBytes).toSet(),
+                sha256 = sha256,
+                loHash = loHash
+            )
         )
     }
 

--- a/p8e-sdk/src/test/kotlin/io/p8e/proxy/PermissionUpdaterTest.kt
+++ b/p8e-sdk/src/test/kotlin/io/p8e/proxy/PermissionUpdaterTest.kt
@@ -1,0 +1,189 @@
+package io.p8e.proxy
+
+import com.nhaarman.mockitokotlin2.eq
+import io.p8e.ContractManager
+import io.p8e.client.P8eClient
+import io.p8e.index.client.IndexClient
+import io.p8e.proto.Common
+import io.p8e.proto.Contracts
+import io.p8e.util.base64Sha512
+import io.p8e.util.base64String
+import io.p8e.util.loBytes
+import io.p8e.util.sha256
+import io.p8e.util.sha512
+import io.provenance.p8e.encryption.ecies.ProvenanceKeyGenerator
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatcher
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.any
+import org.mockito.Mockito.argThat
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.nio.file.Files.readAllBytes
+import java.security.PublicKey
+import javax.management.Query.eq
+import kotlin.random.Random
+
+fun <T> nonNullArgThat(ret: T, matcher: ArgumentMatcher<T>): T {
+    ArgumentMatchers.argThat<T>(matcher)
+    return ret
+}
+
+class PermissionUpdaterTest {
+    lateinit var contractManager: ContractManager
+    val keyPairs = listOf(
+        ProvenanceKeyGenerator.generateKeyPair(),
+        ProvenanceKeyGenerator.generateKeyPair()
+    )
+    val audience: Set<PublicKey> = keyPairs.map { it.public }.toSet()
+
+    @BeforeEach
+    fun setup() {
+        val client = mock(P8eClient::class.java)
+        val indexClient = mock(IndexClient::class.java)
+        contractManager = ContractManager(
+            client,
+            indexClient,
+            keyPairs[0],
+        )
+    }
+
+    fun getPermissionUpdater(records: List<Contracts.Fact>): PermissionUpdater {
+        return PermissionUpdater(
+            contractManager,
+            Contracts.Contract.newBuilder()
+                .addAllInputs(records)
+                .build(),
+            audience,
+        )
+    }
+
+    @Test
+    fun `PermissionUpdater properly handles sha512 hash saving`() {
+        val bytes = Random.nextBytes(1000)
+        val sha512Hash = bytes.base64Sha512()
+
+        val records = listOf(Contracts.Fact.newBuilder()
+            .apply {
+                dataLocationBuilder.refBuilder.hash = sha512Hash
+            }
+            .build())
+        `when`(contractManager.client.loadObject(sha512Hash)).thenReturn(bytes)
+
+        val permissionUpdater = getPermissionUpdater(records)
+
+        `when`(contractManager.client.storeObject(
+            nonNullArgThat(ByteArrayInputStream(bytes)) { stream -> stream.readAllBytes().contentEquals(bytes).also { stream.reset() } },
+            eq(audience), sha256 = eq(false), loHash = eq(false))
+        ).thenReturn(
+            Common.Location.getDefaultInstance()
+        )
+
+        permissionUpdater.saveConstructorArguments()
+
+        verify(contractManager.client, times(1)).storeObject(
+            nonNullArgThat(ByteArrayInputStream(bytes)) { stream -> stream.readAllBytes().contentEquals(bytes).also { stream.reset() } },
+            eq(audience),
+            sha256 = eq(false), // properly detected NOT sha256 (sha512)
+            loHash = eq(false) // properly detected full hash
+        )
+    }
+
+    @Test
+    fun `PermissionUpdater properly handles sha256 hash saving`() {
+        val bytes = Random.nextBytes(1000)
+        val sha256Hash = bytes.sha256().base64String()
+
+        val records = listOf(Contracts.Fact.newBuilder()
+            .apply {
+                dataLocationBuilder.refBuilder.hash = sha256Hash
+            }
+            .build())
+        `when`(contractManager.client.loadObject(sha256Hash)).thenReturn(bytes)
+
+        val permissionUpdater = getPermissionUpdater(records)
+
+        `when`(contractManager.client.storeObject(
+            nonNullArgThat(ByteArrayInputStream(bytes)) { stream -> stream.readAllBytes().contentEquals(bytes).also { stream.reset() } },
+            eq(audience), sha256 = eq(false), loHash = eq(false))
+        ).thenReturn(
+            Common.Location.getDefaultInstance()
+        )
+
+        permissionUpdater.saveConstructorArguments()
+
+        verify(contractManager.client, times(1)).storeObject(
+            nonNullArgThat(ByteArrayInputStream(bytes)) { stream -> stream.readAllBytes().contentEquals(bytes).also { stream.reset() } },
+            eq(audience),
+            sha256 = eq(true), // properly detected sha256
+            loHash = eq(false) // properly detected full hash
+        )
+    }
+
+    @Test
+    fun `PermissionUpdater properly handles sha256 loBytes hash saving`() {
+        val bytes = Random.nextBytes(1000)
+        val sha256LoHash = bytes.sha256().loBytes().toByteArray().base64String()
+
+        val records = listOf(Contracts.Fact.newBuilder()
+            .apply {
+                dataLocationBuilder.refBuilder.hash = sha256LoHash
+            }
+            .build())
+        `when`(contractManager.client.loadObject(sha256LoHash)).thenReturn(bytes)
+
+        val permissionUpdater = getPermissionUpdater(records)
+
+        `when`(contractManager.client.storeObject(
+            nonNullArgThat(ByteArrayInputStream(bytes)) { stream -> stream.readAllBytes().contentEquals(bytes).also { stream.reset() } },
+            eq(audience), sha256 = eq(false), loHash = eq(false))
+        ).thenReturn(
+            Common.Location.getDefaultInstance()
+        )
+
+        permissionUpdater.saveConstructorArguments()
+
+        verify(contractManager.client, times(1)).storeObject(
+            nonNullArgThat(ByteArrayInputStream(bytes)) { stream -> stream.readAllBytes().contentEquals(bytes).also { stream.reset() } },
+            eq(audience),
+            sha256 = eq(true), // properly detected sha256
+            loHash = eq(true) // properly detected loBytes hash (first 16 bytes)
+        )
+    }
+
+    @Test
+    fun `PermissionUpdater properly handles sha512 loBytes hash saving`() {
+        val bytes = Random.nextBytes(1000)
+        val sha256LoHash = bytes.sha512().loBytes().toByteArray().base64String()
+
+        val records = listOf(Contracts.Fact.newBuilder()
+            .apply {
+                dataLocationBuilder.refBuilder.hash = sha256LoHash
+            }
+            .build())
+        `when`(contractManager.client.loadObject(sha256LoHash)).thenReturn(bytes)
+
+        val permissionUpdater = getPermissionUpdater(records)
+
+        `when`(contractManager.client.storeObject(
+            nonNullArgThat(ByteArrayInputStream(bytes)) { stream -> stream.readAllBytes().contentEquals(bytes).also { stream.reset() } },
+            eq(audience), sha256 = eq(false), loHash = eq(false))
+        ).thenReturn(
+            Common.Location.getDefaultInstance()
+        )
+
+        permissionUpdater.saveConstructorArguments()
+
+        verify(contractManager.client, times(1)).storeObject(
+            nonNullArgThat(ByteArrayInputStream(bytes)) { stream -> stream.readAllBytes().contentEquals(bytes).also { stream.reset() } },
+            eq(audience),
+            sha256 = eq(false), // properly detected sha256
+            loHash = eq(true) // properly detected loBytes hash (first 16 bytes)
+        )
+    }
+}

--- a/p8e-util/src/main/kotlin/io/p8e/util/Extensions.kt
+++ b/p8e-util/src/main/kotlin/io/p8e/util/Extensions.kt
@@ -35,6 +35,15 @@ fun String.base64Encode() = String(Base64.getEncoder().encode(toByteArray()))
 
 fun String.base64Decode() = Base64.getDecoder().decode(this)
 
+/* SHA-256 Functionality for interoperability with p8e-scope-sdk */
+fun ByteArray.sha256() = Hashing.sha256().hashBytes(this).asBytes()
+fun ByteArray.loBytes() = slice(0 until 16)
+fun ByteArray.sha256LoBytes(): ByteArray {
+    return Hashing.sha256().hashBytes(this)
+        .asBytes()
+        .loBytes()
+        .toByteArray()
+}
 
 fun ByteArray.sha512(): ByteArray = Hashing.sha512().hashBytes(this).asBytes()
 


### PR DESCRIPTION
- scope records written with the p8e-scope-sdk will be sha256 hashes, while this uses only sha512 hashes. When a scope record from p8e-scope-sdk was used as a contract input for a p8e-api contract, this would result in additional parties not being able to find facts in the scope, as they would have been loaded/decrypted/encrypted to new audience/saved under a sha512 hash that is different from the sha256 currently in the scope.
- This allows the scope facts re-saved by PermissionUpdater to be saved/permissioned in object store under the correct sha256 hash
- This functionality was brought over and slightly modified to be fully parameterized from p8e-scope-sdk
- The loHash functionality shouldn't be needed in p8e-api, but I brought it over in case there turns out to be a need with further testing of the p8e-api/p8e-scope-sdk interop situations (the loHash should be strictly for jar hashes with bootstrapped contracts for p8e-scope-sdk, which p8e-api shouldn't attempt to run)
- I was able to recreate the situation locally by creating a scope w/ a p8e-scope-sdk contract and then running a traditional p8e contract against the scope that took in an existing scope record