### PR TITLE
add MsgP8eMemorializeContractRequest message-based fee to calc

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/config/Properties.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/config/Properties.kt
@@ -57,6 +57,7 @@ class ChaincodeProperties {
     @NotNull var gasMultiplier: Double = 1.0
     @NotNull var maxGasMultiplierPerDay: Int = 1000
     @NotNull var blockHeightTimeoutInterval: Int = 20
+    @NotNull var memorializeMsgFeeNanoHash: Long = 10
 }
 
 @ConfigurationProperties(prefix = "elasticsearch")

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ChaincodeInvokeService.kt
@@ -79,6 +79,8 @@ class ChaincodeInvokeService(
                 scopeLockHeights.remove(it.key) // we only want to log this error once per scope
             }
         }
+
+        private val MEMORIALIZE_MESSAGE_TYPEURL = MsgP8eMemorializeContractRequest.getDefaultInstance().toAny().typeUrl
     }
 
     private val objectMapper = ObjectMapper().configureProvenance()
@@ -463,6 +465,9 @@ class ChaincodeInvokeService(
         } else {
             log.info("skipping gasMultiplier due to daily limit")
         }
+
+        estimate.messageFeesNanoHash = body.messagesList.count { it.typeUrl == MEMORIALIZE_MESSAGE_TYPEURL } * chaincodeProperties.memorializeMsgFeeNanoHash
+        log.info("Adding additional message fee of ${estimate.messageFeesNanoHash}nhash (${estimate.messageFeesNanoHash / 1000000000L}hash) for ${body.messagesList.size} messages")
 
         return provenanceGrpc.batchTx(body, accountNumber, sequenceNumber, estimate)
     }

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ProvenanceGrpcService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ProvenanceGrpcService.kt
@@ -219,11 +219,12 @@ data class GasEstimate(val estimate: Long, val feeAdjustment: Double? = DEFAULT_
 
     private val adjustment = feeAdjustment ?: DEFAULT_FEE_ADJUSTMENT
     private var gasMultiplier = 1.0
+    var messageFeesNanoHash = 0L
 
     fun setGasMultiplier(multiplier: Double) { gasMultiplier = multiplier }
 
     val limit
         get() = (estimate * adjustment * gasMultiplier).roundUp()
     val fees
-        get() = (limit * DEFAULT_GAS_PRICE).roundUp()
+        get() = (limit * DEFAULT_GAS_PRICE + messageFeesNanoHash).roundUp()
 }

--- a/p8e-api/src/main/resources/application-container.properties
+++ b/p8e-api/src/main/resources/application-container.properties
@@ -47,6 +47,7 @@ chaincode.txBatchSize=${CHAINCODE_TX_BATCH_SIZE:25}
 chaincode.gasMultiplier=${CHAINCODE_GAS_MULTIPLIER:1.0}
 chaincode.maxGasMultiplierPerDay=${CHAINCODE_MAX_GAS_MULTIPLIER_PER_DAY:1000}
 chaincode.blockHeightTimeoutInterval=${CHAINCODE_BLOCK_HEIGHT_TIMEOUT_INTERVAL:20}
+chaincode.memorializeMsgFeeNanoHash=${CHAINCODE_MEMORIALIZE_MSG_FEE_NANO_HASH:10000000000}
 
 # Elasticsearch
 elasticsearch.host=${ELASTICSEARCH_HOST}


### PR DESCRIPTION
I believe p8e will need this for the new 1.8 release, an additional fee of 10 hash per MsgP8eMemorializeContractRequest