### PR TITLE
configurable options for fetching/injecting gas price dynamically

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/config/Properties.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/config/Properties.kt
@@ -58,6 +58,9 @@ class ChaincodeProperties {
     @NotNull var maxGasMultiplierPerDay: Int = 1000
     @NotNull var blockHeightTimeoutInterval: Int = 20
     @NotNull var memorializeMsgFeeNanoHash: Long = 10
+    var gasPriceUrl: String? = null
+    @NotNull var defaultGasPrice: Double = 19050.0
+    @NotNull var gasPriceCacheDurationSeconds: Long = 3600
 }
 
 @ConfigurationProperties(prefix = "elasticsearch")

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/GasPriceService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/GasPriceService.kt
@@ -1,0 +1,57 @@
+package io.provenance.engine.service
+
+import feign.RequestLine
+import io.provenance.p8e.shared.extension.logger
+import org.springframework.stereotype.Component
+import java.lang.IllegalStateException
+import java.time.Duration
+import java.time.OffsetDateTime
+
+interface GasPriceService {
+    fun getGasPriceNHash(): Double
+}
+
+class UrlGasPriceService(val client: UrlGasPriceClient, val fallbackPriceNHash: Double): GasPriceService {
+    private val log = logger()
+
+    override fun getGasPriceNHash(): Double = runCatching {
+        client.gasPriceDetails().let {
+            if (it.gasPriceDenom != "nhash") {
+                throw IllegalStateException("Unsupported denom of ${it.gasPriceDenom} received for gas price resolution, required: nhash")
+            }
+
+            log.info("Fetched gas price of ${it.gasPrice}${it.gasPriceDenom}")
+
+            it.gasPrice
+        }
+    }.getOrElse {
+        log.warn("Using fallback gas price of ${fallbackPriceNHash}nhash")
+        fallbackPriceNHash
+    }
+}
+
+class ConstantGasPriceService(val gasPrice: Double): GasPriceService {
+    override fun getGasPriceNHash(): Double = gasPrice
+}
+
+class CachedGasPriceService(val inner: GasPriceService, val cacheDuration: Duration): GasPriceService {
+    private var lastFetched: OffsetDateTime = OffsetDateTime.now()
+    private var lastFetchedPrice: Double = inner.getGasPriceNHash()
+
+    override fun getGasPriceNHash(): Double {
+        if (OffsetDateTime.now().isAfter(lastFetched.plusSeconds(cacheDuration.seconds))) {
+            lastFetchedPrice = inner.getGasPriceNHash()
+            lastFetched = OffsetDateTime.now()
+        }
+
+        return lastFetchedPrice
+    }
+}
+
+data class GasPriceResponse(val gasPrice: Double, val gasPriceDenom: String)
+
+@Component
+interface UrlGasPriceClient {
+    @RequestLine("GET /")
+    fun gasPriceDetails(): GasPriceResponse
+}

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/GasPriceService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/GasPriceService.kt
@@ -35,16 +35,16 @@ class ConstantGasPriceService(val gasPrice: Double): GasPriceService {
 }
 
 class CachedGasPriceService(val inner: GasPriceService, val cacheDuration: Duration): GasPriceService {
-    private var lastFetched: OffsetDateTime = OffsetDateTime.now()
-    private var lastFetchedPrice: Double = inner.getGasPriceNHash()
+    private data class GasPriceCache(val price: Double, val time: OffsetDateTime = OffsetDateTime.now())
+
+    private var lastFetched = GasPriceCache(inner.getGasPriceNHash())
 
     override fun getGasPriceNHash(): Double {
-        if (OffsetDateTime.now().isAfter(lastFetched.plusSeconds(cacheDuration.seconds))) {
-            lastFetchedPrice = inner.getGasPriceNHash()
-            lastFetched = OffsetDateTime.now()
+        if (OffsetDateTime.now().isAfter(lastFetched.time.plusSeconds(cacheDuration.seconds))) {
+            lastFetched = GasPriceCache(inner.getGasPriceNHash())
         }
 
-        return lastFetchedPrice
+        return lastFetched.price
     }
 }
 

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ProvenanceGrpcService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ProvenanceGrpcService.kt
@@ -33,7 +33,6 @@ import io.provenance.metadata.v1.ScopeSpecificationsAllRequest
 import io.provenance.p8e.shared.extension.logger
 import io.provenance.p8e.shared.service.AffiliateService
 import io.provenance.pbc.clients.roundUp
-import org.kethereum.DEFAULT_GAS_PRICE
 import org.kethereum.crypto.getCompressedPublicKey
 import org.springframework.stereotype.Service
 import java.net.URI

--- a/p8e-api/src/main/kotlin/io/provenance/engine/service/ProvenanceGrpcService.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/service/ProvenanceGrpcService.kt
@@ -33,6 +33,7 @@ import io.provenance.metadata.v1.ScopeSpecificationsAllRequest
 import io.provenance.p8e.shared.extension.logger
 import io.provenance.p8e.shared.service.AffiliateService
 import io.provenance.pbc.clients.roundUp
+import org.kethereum.DEFAULT_GAS_PRICE
 import org.kethereum.crypto.getCompressedPublicKey
 import org.springframework.stereotype.Service
 import java.net.URI
@@ -49,6 +50,7 @@ class ProvenanceGrpcService(
     private val accountProvider: Account,
     private val chaincodeProperties: ChaincodeProperties,
     private val affiliateService: AffiliateService,
+    private val gasPriceService: GasPriceService,
 ) {
     companion object {
         val executor = ThreadPoolFactory.newFixedThreadPool(5, "prov-grpc-%d")
@@ -81,6 +83,9 @@ class ProvenanceGrpcService(
     private val keyPair = accountProvider.getKeyPair()
     private val signer = PbSigner.signerFor(keyPair)
 
+    private val gasPrice: Double
+        get() = gasPriceService.getGasPriceNHash()
+
     fun accountInfo(): Auth.BaseAccount = accountService.account(QueryOuterClass.QueryAccountRequest.newBuilder()
             .setAddress(bech32Address)
             .build()
@@ -92,7 +97,7 @@ class ProvenanceGrpcService(
 
     fun getTx(hash: String): TxResponse = txService.getTx(GetTxRequest.newBuilder().setHash(hash).build()).txResponse
 
-    fun signTx(body: TxBody, accountNumber: Long, sequenceNumber: Long, gasEstimate: GasEstimate = GasEstimate(0)): Tx {
+    fun signTx(body: TxBody, accountNumber: Long, sequenceNumber: Long, gasEstimate: GasEstimate = GasEstimate(0, gasPrice = gasPrice)): Tx {
         val authInfo = AuthInfo.newBuilder()
             .setFee(Fee.newBuilder()
                 .addAllAmount(listOf(
@@ -141,7 +146,7 @@ class ProvenanceGrpcService(
                 .setTx(it)
                 .build()
             )
-        }.let { GasEstimate(it.gasInfo.gasUsed) }
+        }.let { GasEstimate(it.gasInfo.gasUsed, gasPrice = gasPrice) }
 
     fun batchTx(body: TxBody, accountNumber: Long, sequenceNumber: Long, estimate: GasEstimate): BroadcastTxResponse =
         signTx(body, accountNumber, sequenceNumber, estimate).run {
@@ -211,10 +216,9 @@ fun Message.toTxBody(): TxBody = listOf(this).toTxBody()
 
 fun Message.toAny(typeUrlPrefix: String = "") = Any.pack(this, typeUrlPrefix)
 
-data class GasEstimate(val estimate: Long, val feeAdjustment: Double? = DEFAULT_FEE_ADJUSTMENT) {
+data class GasEstimate(val estimate: Long, val feeAdjustment: Double? = DEFAULT_FEE_ADJUSTMENT, val gasPrice: Double) {
     companion object {
         private const val DEFAULT_FEE_ADJUSTMENT = 1.25
-        private const val DEFAULT_GAS_PRICE = 1905.00
     }
 
     private val adjustment = feeAdjustment ?: DEFAULT_FEE_ADJUSTMENT
@@ -226,5 +230,5 @@ data class GasEstimate(val estimate: Long, val feeAdjustment: Double? = DEFAULT_
     val limit
         get() = (estimate * adjustment * gasMultiplier).roundUp()
     val fees
-        get() = (limit * DEFAULT_GAS_PRICE + messageFeesNanoHash).roundUp()
+        get() = (limit * gasPrice + messageFeesNanoHash).roundUp()
 }


### PR DESCRIPTION
* Configuration properties to determine where to fetch gas price from, or what gas price to use (/as a fallback)
* Figure provides a gas price at https://test.figure.tech/figure-gas-price
   * Will be a prod version as well soon, can be any url that returns json like below (gasPriceDenom _has_ to be `nhash` for now, or will be rejected and default will be used)
```
 {
    "gasPrice": 19050,
    "gasPriceDenom": "nhash"
}
``` 