### PR TITLE
Event Processing Log Level

### DIFF
--- a/p8e-api/src/main/kotlin/io/provenance/engine/batch/TxErrorReaper.kt
+++ b/p8e-api/src/main/kotlin/io/provenance/engine/batch/TxErrorReaper.kt
@@ -55,7 +55,7 @@ class TxErrorReaper(
                         val blockHeight = transactionStatus.height
                         if (blockHeight <= latestBlockHeight) { // EventStream is past this height, need to process manually
                             transactionStatus.scopeEvents()
-                                .also { events -> log.error("indexing ${events.size} events missed by eventStream") }
+                                .also { events -> log.warn("indexing ${events.size} events missed by eventStream") }
                                 .map { event -> event.toScopeEvent(it.transactionHash.value) }
                                 .also { events -> scopeStream.queueIndexScopes(blockHeight, events) }
                         }


### PR DESCRIPTION
Moves missed event processing log to warn level since this isn't actionable but rather showing that this event is going through an alternative pipeline.

This helps in the case where users have ERROR levels attached to alerting systems.
